### PR TITLE
Use a more consistent name for the compiled module

### DIFF
--- a/bcrypt/__init__.py
+++ b/bcrypt/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import hashlib
 import os
 import sys
 
@@ -38,7 +39,8 @@ else:
     text_type = unicode
 
 
-_bundled_dir = os.path.join(os.path.dirname(__file__), "crypt_blowfish-1.2")
+_crypt_blowfish_dir = "crypt_blowfish-1.2"
+_bundled_dir = os.path.join(os.path.dirname(__file__), _crypt_blowfish_dir)
 
 _ffi = FFI()
 _ffi.cdef("""
@@ -56,7 +58,16 @@ _bcrypt_lib = _ffi.verify('#include "ow-crypt.h"',
         # How can we get distutils to work with a .S file?
         # str(os.path.join(_bundled_dir, "x86.S")),
     ],
-    include_dirs=[str(_bundled_dir)]
+    include_dirs=[str(_bundled_dir)],
+    modulename=str("_".join([
+                    "_cffi",
+                    hashlib.sha1(
+                        "".join(_ffi._cdefsources).encode("utf-8")
+                    ).hexdigest()[:6],
+                    hashlib.sha1(
+                        _crypt_blowfish_dir.encode("utf-8")
+                    ).hexdigest()[:6],
+                ])),
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys
+import os
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -16,6 +17,11 @@ class _AttrDict(dict):
 
     def __setattr__(self, key, value):
         self[key] = value
+
+
+# This is really hacky, but it ensures that if setup_requires are being used
+#   setup.py can import them. No idea why this is required.
+sys.path += [x for x in os.listdir(".") if x.endswith(".egg")]
 
 
 try:
@@ -57,6 +63,9 @@ setup(
     author=__about__.__author__,
     author_email=__about__.__email__,
 
+    setup_requires=[
+        "cffi",
+    ],
     install_requires=[
         "cffi",
     ],
@@ -79,7 +88,6 @@ setup(
         "bcrypt": ["crypt_blowfish-1.2/*"],
     },
 
-    ext_package="bcrypt",
     ext_modules=ext_modules,
 
     zip_safe=False,


### PR DESCRIPTION
CFFI generates a modulename based on the values passed to verify, however this doesn't work very well when those values might change because of installation version runtime. This forces a more consistent name based on values we control instead of values that CFFI deems useful.
