### PR TITLE
Don't attempt to load assembler on i386

### DIFF
--- a/bcrypt/__init__.py
+++ b/bcrypt/__init__.py
@@ -56,6 +56,8 @@ _bcrypt_lib = _ffi.verify('#include "ow-crypt.h"',
         str(os.path.join(_bundled_dir, "crypt_gensalt.c")),
         str(os.path.join(_bundled_dir, "wrapper.c")),
         # How can we get distutils to work with a .S file?
+        #   Set https://github.com/dstufft/bcrypt/blob/4c939e895bd9607301cda6d6f05ef3c1146eb658/bcrypt/crypt_blowfish-1.2/crypt_blowfish.c#L57
+        #      back to 1 if we get ASM loaded.
         # str(os.path.join(_bundled_dir, "x86.S")),
     ],
     include_dirs=[str(_bundled_dir)],

--- a/bcrypt/crypt_blowfish-1.2/crypt_blowfish.c
+++ b/bcrypt/crypt_blowfish-1.2/crypt_blowfish.c
@@ -54,7 +54,7 @@
 #include "crypt_blowfish.h"
 
 #ifdef __i386__
-#define BF_ASM				1
+#define BF_ASM				0
 #define BF_SCALE			1
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM				0


### PR DESCRIPTION
We aren't compiling the .S file because distutils doesn't support it so we need to tell crypt_blowfish not to look for ASM when on i386.
