### PR TITLE
Added a random bytes argument to the gensalt function so one can use his...

### DIFF
--- a/bcrypt/__init__.py
+++ b/bcrypt/__init__.py
@@ -73,8 +73,15 @@ _bcrypt_lib = _ffi.verify('#include "ow-crypt.h"',
 )
 
 
-def gensalt(rounds=12):
-    salt = os.urandom(16)
+def gensalt(rounds=12, random_bytes=None):
+    if random_bytes is None:
+        salt = os.urandom(16)
+    else:
+        if not len(random_bytes) == 16:
+            raise TypeError("random_bytes have the wrong size")
+        if isinstance(random_bytes, text_type):
+            raise TypeError("random_bytes must be encoded before usage")
+        salt = random_bytes
     output = _ffi.new("unsigned char[]", 30)
 
     retval = _bcrypt_lib.crypt_gensalt_rn(


### PR DESCRIPTION
... own salt instead. See issue #13 

https://github.com/pyca/bcrypt/issues/13
