### PR TITLE
Update bcrypt prefix to $2b$

### DIFF
--- a/bcrypt/__init__.py
+++ b/bcrypt/__init__.py
@@ -120,12 +120,15 @@ _ffi.verifier._compile_module = _compile_module
 _bcrypt_lib = LazyLibrary(_ffi)
 
 
-def gensalt(rounds=12):
+def gensalt(rounds=12, prefix=b"2b"):
+    if prefix not in (b"2a", b"2b"):
+        raise TypeError("Supported prefixes are '2a' or '2b'")
+
     salt = os.urandom(16)
     output = _ffi.new("unsigned char[]", 30)
 
     retval = _bcrypt_lib.crypt_gensalt_rn(
-        b"$2a$", rounds, salt, len(salt), output, len(output),
+        b"$" + prefix + b"$", rounds, salt, len(salt), output, len(output),
     )
 
     if not retval:

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -52,6 +52,14 @@ def test_gensalt_rounds_invalid(rounds, monkeypatch):
     with pytest.raises(ValueError):
         bcrypt.gensalt(rounds)
 
+def test_gensalt_bad_prefix():
+    with pytest.raises(TypeError):
+        bcrypt.gensalt(prefix="bad")
+
+def test_gensalt_2a_prefix(monkeypatch):
+    monkeypatch.setattr(os, "urandom", lambda n: b"0000000000000000")
+    assert bcrypt.gensalt(prefix=b"2a") == b"$2a$12$KB.uKB.uKB.uKB.uKB.uK."
+
 
 @pytest.mark.parametrize(("password", "salt", "expected"), [
     (

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -52,9 +52,11 @@ def test_gensalt_rounds_invalid(rounds, monkeypatch):
     with pytest.raises(ValueError):
         bcrypt.gensalt(rounds)
 
+
 def test_gensalt_bad_prefix():
     with pytest.raises(TypeError):
         bcrypt.gensalt(prefix="bad")
+
 
 def test_gensalt_2a_prefix(monkeypatch):
     monkeypatch.setattr(os, "urandom", lambda n: b"0000000000000000")

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -14,31 +14,31 @@ def test_raise_implicit_compile():
 
 def test_gensalt_basic(monkeypatch):
     monkeypatch.setattr(os, "urandom", lambda n: b"0000000000000000")
-    assert bcrypt.gensalt() == b"$2a$12$KB.uKB.uKB.uKB.uKB.uK."
+    assert bcrypt.gensalt() == b"$2b$12$KB.uKB.uKB.uKB.uKB.uK."
 
 
 @pytest.mark.parametrize(("rounds", "expected"), [
-    (4, b"$2a$04$KB.uKB.uKB.uKB.uKB.uK."),
-    (5, b"$2a$05$KB.uKB.uKB.uKB.uKB.uK."),
-    (6, b"$2a$06$KB.uKB.uKB.uKB.uKB.uK."),
-    (7, b"$2a$07$KB.uKB.uKB.uKB.uKB.uK."),
-    (8, b"$2a$08$KB.uKB.uKB.uKB.uKB.uK."),
-    (9, b"$2a$09$KB.uKB.uKB.uKB.uKB.uK."),
-    (10, b"$2a$10$KB.uKB.uKB.uKB.uKB.uK."),
-    (11, b"$2a$11$KB.uKB.uKB.uKB.uKB.uK."),
-    (12, b"$2a$12$KB.uKB.uKB.uKB.uKB.uK."),
-    (13, b"$2a$13$KB.uKB.uKB.uKB.uKB.uK."),
-    (14, b"$2a$14$KB.uKB.uKB.uKB.uKB.uK."),
-    (15, b"$2a$15$KB.uKB.uKB.uKB.uKB.uK."),
-    (16, b"$2a$16$KB.uKB.uKB.uKB.uKB.uK."),
-    (17, b"$2a$17$KB.uKB.uKB.uKB.uKB.uK."),
-    (18, b"$2a$18$KB.uKB.uKB.uKB.uKB.uK."),
-    (19, b"$2a$19$KB.uKB.uKB.uKB.uKB.uK."),
-    (20, b"$2a$20$KB.uKB.uKB.uKB.uKB.uK."),
-    (21, b"$2a$21$KB.uKB.uKB.uKB.uKB.uK."),
-    (22, b"$2a$22$KB.uKB.uKB.uKB.uKB.uK."),
-    (23, b"$2a$23$KB.uKB.uKB.uKB.uKB.uK."),
-    (24, b"$2a$24$KB.uKB.uKB.uKB.uKB.uK."),
+    (4, b"$2b$04$KB.uKB.uKB.uKB.uKB.uK."),
+    (5, b"$2b$05$KB.uKB.uKB.uKB.uKB.uK."),
+    (6, b"$2b$06$KB.uKB.uKB.uKB.uKB.uK."),
+    (7, b"$2b$07$KB.uKB.uKB.uKB.uKB.uK."),
+    (8, b"$2b$08$KB.uKB.uKB.uKB.uKB.uK."),
+    (9, b"$2b$09$KB.uKB.uKB.uKB.uKB.uK."),
+    (10, b"$2b$10$KB.uKB.uKB.uKB.uKB.uK."),
+    (11, b"$2b$11$KB.uKB.uKB.uKB.uKB.uK."),
+    (12, b"$2b$12$KB.uKB.uKB.uKB.uKB.uK."),
+    (13, b"$2b$13$KB.uKB.uKB.uKB.uKB.uK."),
+    (14, b"$2b$14$KB.uKB.uKB.uKB.uKB.uK."),
+    (15, b"$2b$15$KB.uKB.uKB.uKB.uKB.uK."),
+    (16, b"$2b$16$KB.uKB.uKB.uKB.uKB.uK."),
+    (17, b"$2b$17$KB.uKB.uKB.uKB.uKB.uK."),
+    (18, b"$2b$18$KB.uKB.uKB.uKB.uKB.uK."),
+    (19, b"$2b$19$KB.uKB.uKB.uKB.uKB.uK."),
+    (20, b"$2b$20$KB.uKB.uKB.uKB.uKB.uK."),
+    (21, b"$2b$21$KB.uKB.uKB.uKB.uKB.uK."),
+    (22, b"$2b$22$KB.uKB.uKB.uKB.uKB.uK."),
+    (23, b"$2b$23$KB.uKB.uKB.uKB.uKB.uK."),
+    (24, b"$2b$24$KB.uKB.uKB.uKB.uKB.uK."),
 ])
 def test_gensalt_rounds_valid(rounds, expected, monkeypatch):
     monkeypatch.setattr(os, "urandom", lambda n: b"0000000000000000")
@@ -56,103 +56,103 @@ def test_gensalt_rounds_invalid(rounds, monkeypatch):
 @pytest.mark.parametrize(("password", "salt", "expected"), [
     (
         b"Kk4DQuMMfZL9o",
-        b"$2a$04$cVWp4XaNU8a4v1uMRum2SO",
-        b"$2a$04$cVWp4XaNU8a4v1uMRum2SO026BWLIoQMD/TXg5uZV.0P.uO8m3YEm",
+        b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
+        b"$2b$04$cVWp4XaNU8a4v1uMRum2SO026BWLIoQMD/TXg5uZV.0P.uO8m3YEm",
     ),
     (
         b"9IeRXmnGxMYbs",
-        b"$2a$04$pQ7gRO7e6wx/936oXhNjrO",
-        b"$2a$04$pQ7gRO7e6wx/936oXhNjrOUNOHL1D0h1N2IDbJZYs.1ppzSof6SPy",
+        b"$2b$04$pQ7gRO7e6wx/936oXhNjrO",
+        b"$2b$04$pQ7gRO7e6wx/936oXhNjrOUNOHL1D0h1N2IDbJZYs.1ppzSof6SPy",
     ),
     (
         b"xVQVbwa1S0M8r",
-        b"$2a$04$SQe9knOzepOVKoYXo9xTte",
-        b"$2a$04$SQe9knOzepOVKoYXo9xTteNYr6MBwVz4tpriJVe3PNgYufGIsgKcW",
+        b"$2b$04$SQe9knOzepOVKoYXo9xTte",
+        b"$2b$04$SQe9knOzepOVKoYXo9xTteNYr6MBwVz4tpriJVe3PNgYufGIsgKcW",
     ),
     (
         b"Zfgr26LWd22Za",
-        b"$2a$04$eH8zX.q5Q.j2hO1NkVYJQO",
-        b"$2a$04$eH8zX.q5Q.j2hO1NkVYJQOM6KxntS/ow3.YzVmFrE4t//CoF4fvne",
+        b"$2b$04$eH8zX.q5Q.j2hO1NkVYJQO",
+        b"$2b$04$eH8zX.q5Q.j2hO1NkVYJQOM6KxntS/ow3.YzVmFrE4t//CoF4fvne",
     ),
     (
         b"Tg4daC27epFBE",
-        b"$2a$04$ahiTdwRXpUG2JLRcIznxc.",
-        b"$2a$04$ahiTdwRXpUG2JLRcIznxc.s1.ydaPGD372bsGs8NqyYjLY1inG5n2",
+        b"$2b$04$ahiTdwRXpUG2JLRcIznxc.",
+        b"$2b$04$ahiTdwRXpUG2JLRcIznxc.s1.ydaPGD372bsGs8NqyYjLY1inG5n2",
     ),
     (
         b"xhQPMmwh5ALzW",
-        b"$2a$04$nQn78dV0hGHf5wUBe0zOFu",
-        b"$2a$04$nQn78dV0hGHf5wUBe0zOFu8n07ZbWWOKoGasZKRspZxtt.vBRNMIy",
+        b"$2b$04$nQn78dV0hGHf5wUBe0zOFu",
+        b"$2b$04$nQn78dV0hGHf5wUBe0zOFu8n07ZbWWOKoGasZKRspZxtt.vBRNMIy",
     ),
     (
         b"59je8h5Gj71tg",
-        b"$2a$04$cvXudZ5ugTg95W.rOjMITu",
-        b"$2a$04$cvXudZ5ugTg95W.rOjMITuM1jC0piCl3zF5cmGhzCibHZrNHkmckG",
+        b"$2b$04$cvXudZ5ugTg95W.rOjMITu",
+        b"$2b$04$cvXudZ5ugTg95W.rOjMITuM1jC0piCl3zF5cmGhzCibHZrNHkmckG",
     ),
     (
         b"wT4fHJa2N9WSW",
-        b"$2a$04$YYjtiq4Uh88yUsExO0RNTu",
-        b"$2a$04$YYjtiq4Uh88yUsExO0RNTuEJ.tZlsONac16A8OcLHleWFjVawfGvO",
+        b"$2b$04$YYjtiq4Uh88yUsExO0RNTu",
+        b"$2b$04$YYjtiq4Uh88yUsExO0RNTuEJ.tZlsONac16A8OcLHleWFjVawfGvO",
     ),
     (
         b"uSgFRnQdOgm4S",
-        b"$2a$04$WLTjgY/pZSyqX/fbMbJzf.",
-        b"$2a$04$WLTjgY/pZSyqX/fbMbJzf.qxCeTMQOzgL.CimRjMHtMxd/VGKojMu",
+        b"$2b$04$WLTjgY/pZSyqX/fbMbJzf.",
+        b"$2b$04$WLTjgY/pZSyqX/fbMbJzf.qxCeTMQOzgL.CimRjMHtMxd/VGKojMu",
     ),
     (
         b"tEPtJZXur16Vg",
-        b"$2a$04$2moPs/x/wnCfeQ5pCheMcu",
-        b"$2a$04$2moPs/x/wnCfeQ5pCheMcuSJQ/KYjOZG780UjA/SiR.KsYWNrC7SG",
+        b"$2b$04$2moPs/x/wnCfeQ5pCheMcu",
+        b"$2b$04$2moPs/x/wnCfeQ5pCheMcuSJQ/KYjOZG780UjA/SiR.KsYWNrC7SG",
     ),
     (
         b"vvho8C6nlVf9K",
-        b"$2a$04$HrEYC/AQ2HS77G78cQDZQ.",
-        b"$2a$04$HrEYC/AQ2HS77G78cQDZQ.r44WGcruKw03KHlnp71yVQEwpsi3xl2",
+        b"$2b$04$HrEYC/AQ2HS77G78cQDZQ.",
+        b"$2b$04$HrEYC/AQ2HS77G78cQDZQ.r44WGcruKw03KHlnp71yVQEwpsi3xl2",
     ),
     (
         b"5auCCY9by0Ruf",
-        b"$2a$04$vVYgSTfB8KVbmhbZE/k3R.",
-        b"$2a$04$vVYgSTfB8KVbmhbZE/k3R.ux9A0lJUM4CZwCkHI9fifke2.rTF7MG",
+        b"$2b$04$vVYgSTfB8KVbmhbZE/k3R.",
+        b"$2b$04$vVYgSTfB8KVbmhbZE/k3R.ux9A0lJUM4CZwCkHI9fifke2.rTF7MG",
     ),
     (
         b"GtTkR6qn2QOZW",
-        b"$2a$04$JfoNrR8.doieoI8..F.C1O",
-        b"$2a$04$JfoNrR8.doieoI8..F.C1OQgwE3uTeuardy6lw0AjALUzOARoyf2m",
+        b"$2b$04$JfoNrR8.doieoI8..F.C1O",
+        b"$2b$04$JfoNrR8.doieoI8..F.C1OQgwE3uTeuardy6lw0AjALUzOARoyf2m",
     ),
     (
         b"zKo8vdFSnjX0f",
-        b"$2a$04$HP3I0PUs7KBEzMBNFw7o3O",
-        b"$2a$04$HP3I0PUs7KBEzMBNFw7o3O7f/uxaZU7aaDot1quHMgB2yrwBXsgyy",
+        b"$2b$04$HP3I0PUs7KBEzMBNFw7o3O",
+        b"$2b$04$HP3I0PUs7KBEzMBNFw7o3O7f/uxaZU7aaDot1quHMgB2yrwBXsgyy",
     ),
     (
         b"I9VfYlacJiwiK",
-        b"$2a$04$xnFVhJsTzsFBTeP3PpgbMe",
-        b"$2a$04$xnFVhJsTzsFBTeP3PpgbMeMREb6rdKV9faW54Sx.yg9plf4jY8qT6",
+        b"$2b$04$xnFVhJsTzsFBTeP3PpgbMe",
+        b"$2b$04$xnFVhJsTzsFBTeP3PpgbMeMREb6rdKV9faW54Sx.yg9plf4jY8qT6",
     ),
     (
         b"VFPO7YXnHQbQO",
-        b"$2a$04$WQp9.igoLqVr6Qk70mz6xu",
-        b"$2a$04$WQp9.igoLqVr6Qk70mz6xuRxE0RttVXXdukpR9N54x17ecad34ZF6",
+        b"$2b$04$WQp9.igoLqVr6Qk70mz6xu",
+        b"$2b$04$WQp9.igoLqVr6Qk70mz6xuRxE0RttVXXdukpR9N54x17ecad34ZF6",
     ),
     (
         b"VDx5BdxfxstYk",
-        b"$2a$04$xgZtlonpAHSU/njOCdKztO",
-        b"$2a$04$xgZtlonpAHSU/njOCdKztOPuPFzCNVpB4LGicO4/OGgHv.uKHkwsS",
+        b"$2b$04$xgZtlonpAHSU/njOCdKztO",
+        b"$2b$04$xgZtlonpAHSU/njOCdKztOPuPFzCNVpB4LGicO4/OGgHv.uKHkwsS",
     ),
     (
         b"dEe6XfVGrrfSH",
-        b"$2a$04$2Siw3Nv3Q/gTOIPetAyPr.",
-        b"$2a$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe",
+        b"$2b$04$2Siw3Nv3Q/gTOIPetAyPr.",
+        b"$2b$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe",
     ),
     (
         b"cTT0EAFdwJiLn",
-        b"$2a$04$7/Qj7Kd8BcSahPO4khB8me",
-        b"$2a$04$7/Qj7Kd8BcSahPO4khB8me4ssDJCW3r4OGYqPF87jxtrSyPj5cS5m",
+        b"$2b$04$7/Qj7Kd8BcSahPO4khB8me",
+        b"$2b$04$7/Qj7Kd8BcSahPO4khB8me4ssDJCW3r4OGYqPF87jxtrSyPj5cS5m",
     ),
     (
         b"J8eHUDuxBB520",
-        b"$2a$04$VvlCUKbTMjaxaYJ.k5juoe",
-        b"$2a$04$VvlCUKbTMjaxaYJ.k5juoecpG/7IzcH1AkmqKi.lIZMVIOLClWAk.",
+        b"$2b$04$VvlCUKbTMjaxaYJ.k5juoe",
+        b"$2b$04$VvlCUKbTMjaxaYJ.k5juoecpG/7IzcH1AkmqKi.lIZMVIOLClWAk.",
     ),
 ])
 def test_hashpw_new(password, salt, expected):
@@ -162,83 +162,83 @@ def test_hashpw_new(password, salt, expected):
 @pytest.mark.parametrize(("password", "hashed"), [
     (
         b"Kk4DQuMMfZL9o",
-        b"$2a$04$cVWp4XaNU8a4v1uMRum2SO026BWLIoQMD/TXg5uZV.0P.uO8m3YEm",
+        b"$2b$04$cVWp4XaNU8a4v1uMRum2SO026BWLIoQMD/TXg5uZV.0P.uO8m3YEm",
     ),
     (
         b"9IeRXmnGxMYbs",
-        b"$2a$04$pQ7gRO7e6wx/936oXhNjrOUNOHL1D0h1N2IDbJZYs.1ppzSof6SPy",
+        b"$2b$04$pQ7gRO7e6wx/936oXhNjrOUNOHL1D0h1N2IDbJZYs.1ppzSof6SPy",
     ),
     (
         b"xVQVbwa1S0M8r",
-        b"$2a$04$SQe9knOzepOVKoYXo9xTteNYr6MBwVz4tpriJVe3PNgYufGIsgKcW",
+        b"$2b$04$SQe9knOzepOVKoYXo9xTteNYr6MBwVz4tpriJVe3PNgYufGIsgKcW",
     ),
     (
         b"Zfgr26LWd22Za",
-        b"$2a$04$eH8zX.q5Q.j2hO1NkVYJQOM6KxntS/ow3.YzVmFrE4t//CoF4fvne",
+        b"$2b$04$eH8zX.q5Q.j2hO1NkVYJQOM6KxntS/ow3.YzVmFrE4t//CoF4fvne",
     ),
     (
         b"Tg4daC27epFBE",
-        b"$2a$04$ahiTdwRXpUG2JLRcIznxc.s1.ydaPGD372bsGs8NqyYjLY1inG5n2",
+        b"$2b$04$ahiTdwRXpUG2JLRcIznxc.s1.ydaPGD372bsGs8NqyYjLY1inG5n2",
     ),
     (
         b"xhQPMmwh5ALzW",
-        b"$2a$04$nQn78dV0hGHf5wUBe0zOFu8n07ZbWWOKoGasZKRspZxtt.vBRNMIy",
+        b"$2b$04$nQn78dV0hGHf5wUBe0zOFu8n07ZbWWOKoGasZKRspZxtt.vBRNMIy",
     ),
     (
         b"59je8h5Gj71tg",
-        b"$2a$04$cvXudZ5ugTg95W.rOjMITuM1jC0piCl3zF5cmGhzCibHZrNHkmckG",
+        b"$2b$04$cvXudZ5ugTg95W.rOjMITuM1jC0piCl3zF5cmGhzCibHZrNHkmckG",
     ),
     (
         b"wT4fHJa2N9WSW",
-        b"$2a$04$YYjtiq4Uh88yUsExO0RNTuEJ.tZlsONac16A8OcLHleWFjVawfGvO",
+        b"$2b$04$YYjtiq4Uh88yUsExO0RNTuEJ.tZlsONac16A8OcLHleWFjVawfGvO",
     ),
     (
         b"uSgFRnQdOgm4S",
-        b"$2a$04$WLTjgY/pZSyqX/fbMbJzf.qxCeTMQOzgL.CimRjMHtMxd/VGKojMu",
+        b"$2b$04$WLTjgY/pZSyqX/fbMbJzf.qxCeTMQOzgL.CimRjMHtMxd/VGKojMu",
     ),
     (
         b"tEPtJZXur16Vg",
-        b"$2a$04$2moPs/x/wnCfeQ5pCheMcuSJQ/KYjOZG780UjA/SiR.KsYWNrC7SG",
+        b"$2b$04$2moPs/x/wnCfeQ5pCheMcuSJQ/KYjOZG780UjA/SiR.KsYWNrC7SG",
     ),
     (
         b"vvho8C6nlVf9K",
-        b"$2a$04$HrEYC/AQ2HS77G78cQDZQ.r44WGcruKw03KHlnp71yVQEwpsi3xl2",
+        b"$2b$04$HrEYC/AQ2HS77G78cQDZQ.r44WGcruKw03KHlnp71yVQEwpsi3xl2",
     ),
     (
         b"5auCCY9by0Ruf",
-        b"$2a$04$vVYgSTfB8KVbmhbZE/k3R.ux9A0lJUM4CZwCkHI9fifke2.rTF7MG",
+        b"$2b$04$vVYgSTfB8KVbmhbZE/k3R.ux9A0lJUM4CZwCkHI9fifke2.rTF7MG",
     ),
     (
         b"GtTkR6qn2QOZW",
-        b"$2a$04$JfoNrR8.doieoI8..F.C1OQgwE3uTeuardy6lw0AjALUzOARoyf2m",
+        b"$2b$04$JfoNrR8.doieoI8..F.C1OQgwE3uTeuardy6lw0AjALUzOARoyf2m",
     ),
     (
         b"zKo8vdFSnjX0f",
-        b"$2a$04$HP3I0PUs7KBEzMBNFw7o3O7f/uxaZU7aaDot1quHMgB2yrwBXsgyy",
+        b"$2b$04$HP3I0PUs7KBEzMBNFw7o3O7f/uxaZU7aaDot1quHMgB2yrwBXsgyy",
     ),
     (
         b"I9VfYlacJiwiK",
-        b"$2a$04$xnFVhJsTzsFBTeP3PpgbMeMREb6rdKV9faW54Sx.yg9plf4jY8qT6",
+        b"$2b$04$xnFVhJsTzsFBTeP3PpgbMeMREb6rdKV9faW54Sx.yg9plf4jY8qT6",
     ),
     (
         b"VFPO7YXnHQbQO",
-        b"$2a$04$WQp9.igoLqVr6Qk70mz6xuRxE0RttVXXdukpR9N54x17ecad34ZF6",
+        b"$2b$04$WQp9.igoLqVr6Qk70mz6xuRxE0RttVXXdukpR9N54x17ecad34ZF6",
     ),
     (
         b"VDx5BdxfxstYk",
-        b"$2a$04$xgZtlonpAHSU/njOCdKztOPuPFzCNVpB4LGicO4/OGgHv.uKHkwsS",
+        b"$2b$04$xgZtlonpAHSU/njOCdKztOPuPFzCNVpB4LGicO4/OGgHv.uKHkwsS",
     ),
     (
         b"dEe6XfVGrrfSH",
-        b"$2a$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe",
+        b"$2b$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe",
     ),
     (
         b"cTT0EAFdwJiLn",
-        b"$2a$04$7/Qj7Kd8BcSahPO4khB8me4ssDJCW3r4OGYqPF87jxtrSyPj5cS5m",
+        b"$2b$04$7/Qj7Kd8BcSahPO4khB8me4ssDJCW3r4OGYqPF87jxtrSyPj5cS5m",
     ),
     (
         b"J8eHUDuxBB520",
-        b"$2a$04$VvlCUKbTMjaxaYJ.k5juoecpG/7IzcH1AkmqKi.lIZMVIOLClWAk.",
+        b"$2b$04$VvlCUKbTMjaxaYJ.k5juoecpG/7IzcH1AkmqKi.lIZMVIOLClWAk.",
     ),
 ])
 def test_hashpw_existing(password, hashed):
@@ -254,7 +254,7 @@ def test_hashpw_str_password():
     with pytest.raises(TypeError):
         bcrypt.hashpw(
             six.text_type("password"),
-            b"$2a$04$cVWp4XaNU8a4v1uMRum2SO",
+            b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
         )
 
 
@@ -262,5 +262,5 @@ def test_hashpw_str_salt():
     with pytest.raises(TypeError):
         bcrypt.hashpw(
             b"password",
-            six.text_type("$2a$04$cVWp4XaNU8a4v1uMRum2SO"),
+            six.text_type("$2b$04$cVWp4XaNU8a4v1uMRum2SO"),
         )


### PR DESCRIPTION
As mentioned in Issue #25, the new "official" prefix for bcrypt is `$2b$`.  This pull request updates the `gensalt()` method to use `$2b$` by default but provides a new named argument, `prefix`, in case users need to support the old hash output with a `$2a$` prefix.  Any hashes produced by py-bcrypt or older bcrypt can still be verified by these changes (`$2a$`, `$2b$`, and `$2y$` are all equivalent as of the 1.3 library).  On the other hand, py-bcrypt -- which is two years out of date -- will no longer be able to parse default hashes produced by this library.  I understand that comparability with py-bcrypt is important; however, since py-bcrypt has not been updated in almost 2 years, I think it is better for its users if this library breaks comparability.