### PR TITLE
Update README to include additional install steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 bcrypt
 ======
 
-.. image:: https://pypip.in/version/bcrypt/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/nine.svg 
     :target: https://pypi.python.org/pypi/bcrypt/
     :alt: Latest Version
 
@@ -20,6 +20,19 @@ To install bcrypt, simply:
 
     $ pip install bcrypt
 
+Note that bcrypt should build very easily on Linux provided you have a C compiler, headers for Python (if you’re not using pypy), and headers for the libffi libraries available on your system.
+
+For Debian and Ubuntu, the following command will ensure that the required dependencies are installed:
+
+.. code:: bash
+
+    $ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
+
+For Fedora and RHEL-derivatives, the following command will ensure that the required dependencies are installed:
+
+.. code:: bash
+
+    $ sudo yum install gcc libffi-devel python-devel openssl-devel
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 bcrypt
 ======
 
-.. image:: https://img.shields.io/pypi/v/nine.svg 
+.. image:: https://img.shields.io/pypi/v/bcrypt.svg 
     :target: https://pypi.python.org/pypi/bcrypt/
     :alt: Latest Version
 
@@ -26,13 +26,13 @@ For Debian and Ubuntu, the following command will ensure that the required depen
 
 .. code:: bash
 
-    $ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
+    $ sudo apt-get install build-essential libffi-dev python-dev
 
 For Fedora and RHEL-derivatives, the following command will ensure that the required dependencies are installed:
 
 .. code:: bash
 
-    $ sudo yum install gcc libffi-devel python-devel openssl-devel
+    $ sudo yum install gcc libffi-devel python-devel
 
 Usage
 -----


### PR DESCRIPTION
This was helpfully pointed out in https://github.com/pyca/bcrypt/issues/41 by @jbolda.

The only package I needed was ```libffi-dev```, so maybe someone can confirm the full list.  I also fixed your PyPi badge.