### PR TITLE
raise a decent error if pypy <2.6 + update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Compatibility
 -------------
 
 This library should be compatible with py-bcrypt and it will run on Python
-2.6+, 3.3+, and PyPy.
+2.6+, 3.3+, and PyPy 2.6+.
 
 Security
 --------

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import platform
 import sys
 from distutils.command.build import build
 
@@ -20,6 +21,14 @@ CFFI_MODULES = [
 __about__ = {}
 with open("src/bcrypt/__about__.py") as fp:
     exec(fp.read(), __about__)
+
+
+if platform.python_implementation() == "PyPy":
+    if sys.pypy_version_info < (2, 6):
+        raise RuntimeError(
+            "bcrypt is not compatible with PyPy < 2.6. Please upgrade PyPy to "
+            "use this library."
+        )
 
 
 class PyTest(test):


### PR DESCRIPTION
This resolves the recent comment on #49 that noted we still hadn't put in warnings like we promised to.