### PR TITLE
Add vendor prefixes for public sym names

### DIFF
--- a/src/crypt_blowfish-1.3/crypt_blowfish.c
+++ b/src/crypt_blowfish-1.3/crypt_blowfish.c
@@ -778,7 +778,7 @@ static char *BF_crypt(const char *key, const char *setting,
 	return output;
 }
 
-int _crypt_output_magic(const char *setting, char *output, int size)
+int bcrypt_crypt_output_magic(const char *setting, char *output, int size)
 {
 	if (size < 3)
 		return -1;
@@ -813,7 +813,7 @@ int _crypt_output_magic(const char *setting, char *output, int size)
  * The performance cost of this quick self-test is around 0.6% at the "$2a$08"
  * setting.
  */
-char *_crypt_blowfish_rn(const char *key, const char *setting,
+char *bcrypt_crypt_blowfish_rn(const char *key, const char *setting,
 	char *output, int size)
 {
 	const char *test_key = "8b \xd0\xc1\xd2\xcf\xcc\xd8";
@@ -831,7 +831,7 @@ char *_crypt_blowfish_rn(const char *key, const char *setting,
 	} buf;
 
 /* Hash the supplied password */
-	_crypt_output_magic(setting, output, size);
+	bcrypt_crypt_output_magic(setting, output, size);
 	retval = BF_crypt(key, setting, output, size, 16);
 	save_errno = errno;
 
@@ -873,12 +873,12 @@ char *_crypt_blowfish_rn(const char *key, const char *setting,
 		return retval;
 
 /* Should not happen */
-	_crypt_output_magic(setting, output, size);
+	bcrypt_crypt_output_magic(setting, output, size);
 	__set_errno(EINVAL); /* pretend we don't support this hash type */
 	return NULL;
 }
 
-char *_crypt_gensalt_blowfish_rn(const char *prefix, unsigned long count,
+char *bcrypt_crypt_gensalt_blowfish_rn(const char *prefix, unsigned long count,
 	const char *input, int size, char *output, int output_size)
 {
 	if (size < 16 || output_size < 7 + 22 + 1 ||

--- a/src/crypt_blowfish-1.3/crypt_blowfish.h
+++ b/src/crypt_blowfish-1.3/crypt_blowfish.h
@@ -17,10 +17,10 @@
 #ifndef _CRYPT_BLOWFISH_H
 #define _CRYPT_BLOWFISH_H
 
-extern int _crypt_output_magic(const char *setting, char *output, int size);
-extern char *_crypt_blowfish_rn(const char *key, const char *setting,
+extern int bcrypt_crypt_output_magic(const char *setting, char *output, int size);
+extern char *bcrypt_crypt_blowfish_rn(const char *key, const char *setting,
 	char *output, int size);
-extern char *_crypt_gensalt_blowfish_rn(const char *prefix,
+extern char *bcrypt_crypt_gensalt_blowfish_rn(const char *prefix,
 	unsigned long count,
 	const char *input, int size, char *output, int output_size);
 

--- a/src/crypt_blowfish-1.3/crypt_gensalt.c
+++ b/src/crypt_blowfish-1.3/crypt_gensalt.c
@@ -28,10 +28,10 @@
 /* Just to make sure the prototypes match the actual definitions */
 #include "crypt_gensalt.h"
 
-unsigned char _crypt_itoa64[64 + 1] =
+unsigned char bcrypt_crypt_itoa64[64 + 1] =
 	"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-char *_crypt_gensalt_traditional_rn(const char *prefix, unsigned long count,
+char *bcrypt_crypt_gensalt_traditional_rn(const char *prefix, unsigned long count,
 	const char *input, int size, char *output, int output_size)
 {
 	(void) prefix;
@@ -42,14 +42,14 @@ char *_crypt_gensalt_traditional_rn(const char *prefix, unsigned long count,
 		return NULL;
 	}
 
-	output[0] = _crypt_itoa64[(unsigned int)input[0] & 0x3f];
-	output[1] = _crypt_itoa64[(unsigned int)input[1] & 0x3f];
+	output[0] = bcrypt_crypt_itoa64[(unsigned int)input[0] & 0x3f];
+	output[1] = bcrypt_crypt_itoa64[(unsigned int)input[1] & 0x3f];
 	output[2] = '\0';
 
 	return output;
 }
 
-char *_crypt_gensalt_extended_rn(const char *prefix, unsigned long count,
+char *bcrypt_crypt_gensalt_extended_rn(const char *prefix, unsigned long count,
 	const char *input, int size, char *output, int output_size)
 {
 	unsigned long value;
@@ -68,23 +68,23 @@ char *_crypt_gensalt_extended_rn(const char *prefix, unsigned long count,
 	if (!count) count = 725;
 
 	output[0] = '_';
-	output[1] = _crypt_itoa64[count & 0x3f];
-	output[2] = _crypt_itoa64[(count >> 6) & 0x3f];
-	output[3] = _crypt_itoa64[(count >> 12) & 0x3f];
-	output[4] = _crypt_itoa64[(count >> 18) & 0x3f];
+	output[1] = bcrypt_crypt_itoa64[count & 0x3f];
+	output[2] = bcrypt_crypt_itoa64[(count >> 6) & 0x3f];
+	output[3] = bcrypt_crypt_itoa64[(count >> 12) & 0x3f];
+	output[4] = bcrypt_crypt_itoa64[(count >> 18) & 0x3f];
 	value = (unsigned long)(unsigned char)input[0] |
 		((unsigned long)(unsigned char)input[1] << 8) |
 		((unsigned long)(unsigned char)input[2] << 16);
-	output[5] = _crypt_itoa64[value & 0x3f];
-	output[6] = _crypt_itoa64[(value >> 6) & 0x3f];
-	output[7] = _crypt_itoa64[(value >> 12) & 0x3f];
-	output[8] = _crypt_itoa64[(value >> 18) & 0x3f];
+	output[5] = bcrypt_crypt_itoa64[value & 0x3f];
+	output[6] = bcrypt_crypt_itoa64[(value >> 6) & 0x3f];
+	output[7] = bcrypt_crypt_itoa64[(value >> 12) & 0x3f];
+	output[8] = bcrypt_crypt_itoa64[(value >> 18) & 0x3f];
 	output[9] = '\0';
 
 	return output;
 }
 
-char *_crypt_gensalt_md5_rn(const char *prefix, unsigned long count,
+char *bcrypt_crypt_gensalt_md5_rn(const char *prefix, unsigned long count,
 	const char *input, int size, char *output, int output_size)
 {
 	unsigned long value;
@@ -103,20 +103,20 @@ char *_crypt_gensalt_md5_rn(const char *prefix, unsigned long count,
 	value = (unsigned long)(unsigned char)input[0] |
 		((unsigned long)(unsigned char)input[1] << 8) |
 		((unsigned long)(unsigned char)input[2] << 16);
-	output[3] = _crypt_itoa64[value & 0x3f];
-	output[4] = _crypt_itoa64[(value >> 6) & 0x3f];
-	output[5] = _crypt_itoa64[(value >> 12) & 0x3f];
-	output[6] = _crypt_itoa64[(value >> 18) & 0x3f];
+	output[3] = bcrypt_crypt_itoa64[value & 0x3f];
+	output[4] = bcrypt_crypt_itoa64[(value >> 6) & 0x3f];
+	output[5] = bcrypt_crypt_itoa64[(value >> 12) & 0x3f];
+	output[6] = bcrypt_crypt_itoa64[(value >> 18) & 0x3f];
 	output[7] = '\0';
 
 	if (size >= 6 && output_size >= 3 + 4 + 4 + 1) {
 		value = (unsigned long)(unsigned char)input[3] |
 			((unsigned long)(unsigned char)input[4] << 8) |
 			((unsigned long)(unsigned char)input[5] << 16);
-		output[7] = _crypt_itoa64[value & 0x3f];
-		output[8] = _crypt_itoa64[(value >> 6) & 0x3f];
-		output[9] = _crypt_itoa64[(value >> 12) & 0x3f];
-		output[10] = _crypt_itoa64[(value >> 18) & 0x3f];
+		output[7] = bcrypt_crypt_itoa64[value & 0x3f];
+		output[8] = bcrypt_crypt_itoa64[(value >> 6) & 0x3f];
+		output[9] = bcrypt_crypt_itoa64[(value >> 12) & 0x3f];
+		output[10] = bcrypt_crypt_itoa64[(value >> 18) & 0x3f];
 		output[11] = '\0';
 	}
 

--- a/src/crypt_blowfish-1.3/crypt_gensalt.h
+++ b/src/crypt_blowfish-1.3/crypt_gensalt.h
@@ -17,14 +17,14 @@
 #ifndef _CRYPT_GENSALT_H
 #define _CRYPT_GENSALT_H
 
-extern unsigned char _crypt_itoa64[];
-extern char *_crypt_gensalt_traditional_rn(const char *prefix,
+extern unsigned char bcrypt_crypt_itoa64[];
+extern char *bcrypt_crypt_gensalt_traditional_rn(const char *prefix,
 	unsigned long count,
 	const char *input, int size, char *output, int output_size);
-extern char *_crypt_gensalt_extended_rn(const char *prefix,
+extern char *bcrypt_crypt_gensalt_extended_rn(const char *prefix,
 	unsigned long count,
 	const char *input, int size, char *output, int output_size);
-extern char *_crypt_gensalt_md5_rn(const char *prefix, unsigned long count,
+extern char *bcrypt_crypt_gensalt_md5_rn(const char *prefix, unsigned long count,
 	const char *input, int size, char *output, int output_size);
 
 #endif

--- a/src/crypt_blowfish-1.3/wrapper.c
+++ b/src/crypt_blowfish-1.3/wrapper.c
@@ -90,7 +90,7 @@ static char *_crypt_retval_magic(char *retval, const char *setting,
 	if (retval)
 		return retval;
 
-	if (_crypt_output_magic(setting, output, size))
+	if (bcrypt_crypt_output_magic(setting, output, size))
 		return NULL; /* shouldn't happen */
 
 	return output;
@@ -113,7 +113,7 @@ char *__crypt_rn(__const char *key, __const char *setting,
 	void *data, int size)
 {
 	if (setting[0] == '$' && setting[1] == '2')
-		return _crypt_blowfish_rn(key, setting, (char *)data, size);
+		return bcrypt_crypt_blowfish_rn(key, setting, (char *)data, size);
 	if (setting[0] == '$' && setting[1] == '1')
 		return __md5_crypt_r(key, setting, (char *)data, size);
 	if (setting[0] == '$' || setting[0] == '_') {
@@ -132,7 +132,7 @@ char *__crypt_ra(__const char *key, __const char *setting,
 	if (setting[0] == '$' && setting[1] == '2') {
 		if (_crypt_data_alloc(data, size, CRYPT_OUTPUT_SIZE))
 			return NULL;
-		return _crypt_blowfish_rn(key, setting, (char *)*data, *size);
+		return bcrypt_crypt_blowfish_rn(key, setting, (char *)*data, *size);
 	}
 	if (setting[0] == '$' && setting[1] == '1') {
 		if (_crypt_data_alloc(data, size, CRYPT_OUTPUT_SIZE))
@@ -165,7 +165,7 @@ char *__crypt(__const char *key, __const char *setting)
 #else
 char *crypt_rn(const char *key, const char *setting, void *data, int size)
 {
-	return _crypt_blowfish_rn(key, setting, (char *)data, size);
+	return bcrypt_crypt_blowfish_rn(key, setting, (char *)data, size);
 }
 
 char *crypt_ra(const char *key, const char *setting,
@@ -173,7 +173,7 @@ char *crypt_ra(const char *key, const char *setting,
 {
 	if (_crypt_data_alloc(data, size, CRYPT_OUTPUT_SIZE))
 		return NULL;
-	return _crypt_blowfish_rn(key, setting, (char *)*data, *size);
+	return bcrypt_crypt_blowfish_rn(key, setting, (char *)*data, *size);
 }
 
 char *crypt_r(const char *key, const char *setting, void *data)
@@ -212,19 +212,19 @@ char *__crypt_gensalt_rn(const char *prefix, unsigned long count,
 
 	if (!strncmp(prefix, "$2a$", 4) || !strncmp(prefix, "$2b$", 4) ||
 	    !strncmp(prefix, "$2y$", 4))
-		use = _crypt_gensalt_blowfish_rn;
+		use = bcrypt_crypt_gensalt_blowfish_rn;
 	else
 	if (!strncmp(prefix, "$1$", 3))
-		use = _crypt_gensalt_md5_rn;
+		use = bcrypt_crypt_gensalt_md5_rn;
 	else
 	if (prefix[0] == '_')
-		use = _crypt_gensalt_extended_rn;
+		use = bcrypt_crypt_gensalt_extended_rn;
 	else
 	if (!prefix[0] ||
 	    (prefix[0] && prefix[1] &&
-	    memchr(_crypt_itoa64, prefix[0], 64) &&
-	    memchr(_crypt_itoa64, prefix[1], 64)))
-		use = _crypt_gensalt_traditional_rn;
+	    memchr(bcrypt_crypt_itoa64, prefix[0], 64) &&
+	    memchr(bcrypt_crypt_itoa64, prefix[1], 64)))
+		use = bcrypt_crypt_gensalt_traditional_rn;
 	else {
 		__set_errno(EINVAL);
 		return NULL;


### PR DESCRIPTION
I have added bcrypt_ prefix for all public symbols (excluding crypt* functions from wrapper which are used by CFFI only).

Looks like now it works under Apache and does not interfere with APR's functions.

Actual sym list:

```
$ nm -D build/lib.linux-x86_64-2.7/bcrypt/_bcrypt.so
0000000000003430 T bcrypt_crypt_blowfish_rn
0000000000003750 T bcrypt_crypt_gensalt_blowfish_rn
0000000000003950 T bcrypt_crypt_gensalt_extended_rn
0000000000003ab0 T bcrypt_crypt_gensalt_md5_rn
0000000000003890 T bcrypt_crypt_gensalt_traditional_rn
0000000000206160 D bcrypt_crypt_itoa64
00000000000033f0 T bcrypt_crypt_output_magic
00000000002061a1 B __bss_start
0000000000003d20 T crypt
0000000000003f20 T crypt_gensalt
0000000000003ed0 T crypt_gensalt_ra
0000000000003d80 T crypt_gensalt_rn
0000000000003cd0 T crypt_r
0000000000003c50 T crypt_ra
0000000000003c40 T crypt_rn
                 w __cxa_finalize
00000000002061a1 D _edata
0000000000206320 B _end
                 U __errno_location
0000000000003f34 T _fini
                 w __gmon_start__
0000000000000e50 T _init
0000000000001590 T init_bcrypt
                 w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
                 w _Jv_RegisterClasses
                 U memchr
                 U memcmp
                 U memset
                 U PyErr_Format
                 U PyErr_Occurred
                 U PyEval_RestoreThread
                 U PyEval_SaveThread
                 U PyExc_TypeError
                 U PyImport_ImportModule
                 U PyLong_FromVoidPtr
                 U PyObject_CallMethod
                 U realloc
                 U __stack_chk_fail
                 U __strdup
```