### PR TITLE
Inputing a 2y salt should output a 2y hash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ Changelog
 3.1.0
 -----
 * Added support for ``checkpw`` as another method of verifying a password.
+* Ensure that you get a ``$2y$`` hash when you input a ``$2y$`` salt.
 
 3.0.0
 -----

--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -39,10 +39,6 @@ __all__ = [
 _normalize_re = re.compile(b"^\$2y\$")
 
 
-def _normalize_prefix(salt):
-    return _normalize_re.sub(b"$2b$", salt)
-
-
 def gensalt(rounds=12, prefix=b"2b"):
     if prefix not in (b"2a", b"2b"):
         raise ValueError("Supported prefixes are b'2a' or b'2b'")
@@ -75,7 +71,13 @@ def hashpw(password, salt):
     # on $2a$, so we do it here to preserve compatibility with 2.0.0
     password = password[:72]
 
-    salt = _normalize_prefix(salt)
+    # When the original 8bit bug was found the original library we supported
+    # added a new prefix, $2y$, that fixes it. This prefix is exactly the same
+    # as the $2b$ prefix added by OpenBSD other than the name. Since the
+    # OpenBSD library does not support the $2y$ prefix, if the salt given to us
+    # is for the $2y$ prefix, we'll just mugne it so that it's a $2b$ prior to
+    # passing it into the C library.
+    original_salt, salt = salt, _normalize_re.sub(b"$2b$", salt)
 
     hashed = _bcrypt.ffi.new("unsigned char[]", 128)
     retval = _bcrypt.lib.bcrypt_hashpass(password, salt, hashed, len(hashed))
@@ -83,7 +85,13 @@ def hashpw(password, salt):
     if retval != 0:
         raise ValueError("Invalid salt")
 
-    return _bcrypt.ffi.string(hashed)
+    # Now that we've gotten our hashed password, we want to ensure that the
+    # prefix we return is the one that was passed in, so we'll use the prefix
+    # from the original salt and concatenate that with the return value (minus
+    # the return value's prefix). This will ensure that if someone passed in a
+    # salt with a $2y$ prefix, that they get back a hash with a $2y$ prefix
+    # even though we munged it to $2b$.
+    return original_salt[:4] + _bcrypt.ffi.string(hashed)[4:]
 
 
 def checkpw(password, hashed_password):
@@ -95,9 +103,6 @@ def checkpw(password, hashed_password):
         raise ValueError(
             "password and hashed_password may not contain NUL bytes"
         )
-
-    # If the user supplies a $2y$ prefix we normalize to $2b$
-    hashed_password = _normalize_prefix(hashed_password)
 
     ret = hashpw(password, hashed_password)
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -152,12 +152,12 @@ _2y_test_vectors = [
     (
         b"\xa3",
         b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
-        b"$2b$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
+        b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
     ),
     (
         b"\xff\xff\xa3",
         b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
-        b"$2b$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
+        b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
     ),
 ]
 


### PR DESCRIPTION
Currently using bcrypt 3.0 with passlib is a bit broken, because it it inputs a precomputed ``$2y$`` salt and expects to get back out a ``$2y$`` hash (and it verifies that it does that), however instead it's getting back a ``$2b$`` hash. Giving a ``$2b$`` output when you give it a ``$2y$`` input also means it breaks the most logical way to verify a bcrypt'd password since:

```python
import bcrypt

assert bcrypt.hashpw(plaintext, hashed_with_2y) == hashed_with_2y
```

would fail because instead of a ``$2y$`` we'd return a ``$2b$``.

So this change will ensure that ``hashpw()`` returns the same prefix it was given originally. We still don't support the ``$2y$`` prefix when passed into ``gensalt()``, so getting a ``$2y$`` out of ``hashpw()`` will still require either pre-existing data or manually constructing your own salt.

This also means our ``checkpw`` gets to be a little simpler since it no longer needs to deal with the fact that the output may differ only by the prefix.