### PR TITLE
add build scripts for creating manylinux1 wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,8 @@ include src/build_bcrypt.py
 recursive-include src/_csrc *
 recursive-include tests *.py
 
-exclude requirements.txt tasks.py .travis.yml
+exclude requirements.txt tasks.py .travis.yml wheel-scripts
+
+recursive-exclude wheel-scripts *
 
 prune .travis

--- a/wheel-scripts/build_wheels.sh
+++ b/wheel-scripts/build_wheels.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -x -e
+
+for PYBIN in /opt/python/*/bin; do
+    ${PYBIN}/pip install cffi six -f /io/wheelhouse/
+    ${PYBIN}/pip wheel --no-deps bcrypt -w /wheelhouse/
+done
+
+for whl in /wheelhouse/bcrypt*.whl; do
+    auditwheel repair $whl -w /io/wheelhouse/
+done
+
+for PYBIN in /opt/python/*/bin/; do
+    ${PYBIN}/pip install bcrypt --no-index -f /io/wheelhouse/
+    ${PYBIN}/python -c "import bcrypt;password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());assert hashed"
+done

--- a/wheel-scripts/build_wheels.sh
+++ b/wheel-scripts/build_wheels.sh
@@ -2,15 +2,15 @@
 set -x -e
 
 for PYBIN in /opt/python/*/bin; do
-    ${PYBIN}/pip install cffi six -f /io/wheelhouse/
-    ${PYBIN}/pip wheel --no-deps bcrypt -w /wheelhouse/
+    "${PYBIN}"/pip install cffi six -f /io/wheelhouse/
+    "${PYBIN}"/pip wheel --no-deps bcrypt -w /wheelhouse/
 done
 
 for whl in /wheelhouse/bcrypt*.whl; do
-    auditwheel repair $whl -w /io/wheelhouse/
+    auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
 for PYBIN in /opt/python/*/bin/; do
-    ${PYBIN}/pip install bcrypt --no-index -f /io/wheelhouse/
-    ${PYBIN}/python -c "import bcrypt;password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());assert hashed"
+    "${PYBIN}"/pip install bcrypt --no-index -f /io/wheelhouse/
+    "${PYBIN}"/python -c "import bcrypt;password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());assert hashed"
 done

--- a/wheel-scripts/build_wheels.sh
+++ b/wheel-scripts/build_wheels.sh
@@ -12,5 +12,5 @@ done
 
 for PYBIN in /opt/python/*/bin/; do
     "${PYBIN}"/pip install bcrypt --no-index -f /io/wheelhouse/
-    "${PYBIN}"/python -c "import bcrypt;password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());assert hashed"
+    "${PYBIN}"/python -c "import bcrypt;password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());bcrypt.checkpw(password, hashed)"
 done

--- a/wheel-scripts/docker.sh
+++ b/wheel-scripts/docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build_wheels.sh
+docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_i686 linux32 /io/build_wheels.sh

--- a/wheel-scripts/docker.sh
+++ b/wheel-scripts/docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build_wheels.sh
-docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_i686 linux32 /io/build_wheels.sh
+docker run --rm -v $(pwd):/io quay.io/pypa/manylinux1_x86_64 /io/build_wheels.sh
+docker run --rm -v $(pwd):/io quay.io/pypa/manylinux1_i686 linux32 /io/build_wheels.sh


### PR DESCRIPTION
These scripts will store the manylinux1 wheels in a dir called `wheelhouse` in your current working directory. Note that at the moment these scripts _will not work_ unless you already have that dir and it contains `cffi` manylinux1 wheels (as libffi is not present in the docker container).

This probably shouldn't be merged until it has some documentation on how to use it.
