### PR TITLE
Correctly handle invalid hashed passwords in bcrypt.checkpw.

### DIFF
--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -106,6 +106,9 @@ def checkpw(password, hashed_password):
 
     ret = hashpw(password, hashed_password)
 
+    if len(ret) != len(hashed_password):
+        return False
+
     return _bcrypt.lib.timingsafe_bcmp(ret, hashed_password, len(ret)) == 0
 
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -308,6 +308,15 @@ def test_hashpw_nul_byte():
         bcrypt.hashpw(b"abc\0def", salt)
 
 
+def test_checkpw_extra_data():
+    salt = bcrypt.gensalt(4)
+    hashed = bcrypt.hashpw(b"abc", salt)
+
+    assert bcrypt.checkpw(b"abc", hashed)
+    assert bcrypt.checkpw(b"abc", hashed + b"extra") is False
+    assert bcrypt.checkpw(b"abc", hashed[:-10]) is False
+
+
 @pytest.mark.parametrize(
     ("rounds", "password", "salt", "expected"),
     [[


### PR DESCRIPTION
Previously it would silently accept extra data, and overread a buffer on truncated data.

Reported by Matthew Russell