### PR TITLE
fix UnicodeDecodeError in non-UTF-8 environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import platform
 import sys
+import io
 from distutils.command.build import build
 
 from setuptools import setup
@@ -192,7 +193,7 @@ setup(
     version=__about__["__version__"],
 
     description=__about__["__summary__"],
-    long_description=open("README.rst").read(),
+    long_description=io.open("README.rst", encoding='utf-8').read(),
     url=__about__["__uri__"],
     license=__about__["__license__"],
 


### PR DESCRIPTION
This is from Debian packaging. It fixes UnicodeDecodeError with Python3 in non-UTF-8 enviroments. That way it works for both, Python2 as well as Python3.
Best,
DS
