### PR TITLE
Warn upon too few bcrypt.kdf() rounds

### DIFF
--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -18,6 +18,7 @@ from __future__ import division
 
 import os
 import re
+import sys
 
 import six
 
@@ -112,7 +113,7 @@ def checkpw(password, hashed_password):
     return _bcrypt.lib.timingsafe_bcmp(ret, hashed_password, len(ret)) == 0
 
 
-def kdf(password, salt, desired_key_bytes, rounds):
+def kdf(password, salt, desired_key_bytes, rounds, ignore_few_rounds = False):
     if isinstance(password, six.text_type) or isinstance(salt, six.text_type):
         raise TypeError("Unicode-objects must be encoded before hashing")
 
@@ -124,6 +125,14 @@ def kdf(password, salt, desired_key_bytes, rounds):
 
     if rounds < 1:
         raise ValueError("rounds must be 1 or more")
+
+    if rounds < 50 and not ignore_few_rounds:
+        # They probably think bcrypt.kdf()'s rounds parameter is logarithmic,
+        # expecting this value to be slow enough (it probably would be if this
+        # were bcrypt). Emit a warning.
+        sys.stderr.write(("Warning: bcrypt.kdf() called with only {} round(s). "
+            + "This few is not secure: the parameter is linear, like PBKDF2.\n")
+            .format(rounds))
 
     key = _bcrypt.ffi.new("uint8_t[]", desired_key_bytes)
     res = _bcrypt.lib.bcrypt_pbkdf(

--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -18,7 +18,7 @@ from __future__ import division
 
 import os
 import re
-import sys
+import warnings
 
 import six
 
@@ -130,9 +130,11 @@ def kdf(password, salt, desired_key_bytes, rounds, ignore_few_rounds = False):
         # They probably think bcrypt.kdf()'s rounds parameter is logarithmic,
         # expecting this value to be slow enough (it probably would be if this
         # were bcrypt). Emit a warning.
-        sys.stderr.write(("Warning: bcrypt.kdf() called with only {} round(s). "
-            + "This few is not secure: the parameter is linear, like PBKDF2.\n")
-            .format(rounds))
+        warnings.warn((
+            "Warning: bcrypt.kdf() called with only {} round(s). "
+            "This few is not secure: the parameter is linear, like PBKDF2.")
+            .format(rounds),
+            UserWarning)
 
     key = _bcrypt.ffi.new("uint8_t[]", desired_key_bytes)
     res = _bcrypt.lib.bcrypt_pbkdf(

--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -113,7 +113,7 @@ def checkpw(password, hashed_password):
     return _bcrypt.lib.timingsafe_bcmp(ret, hashed_password, len(ret)) == 0
 
 
-def kdf(password, salt, desired_key_bytes, rounds, ignore_few_rounds = False):
+def kdf(password, salt, desired_key_bytes, rounds, ignore_few_rounds=False):
     if isinstance(password, six.text_type) or isinstance(salt, six.text_type):
         raise TypeError("Unicode-objects must be encoded before hashing")
 
@@ -131,7 +131,7 @@ def kdf(password, salt, desired_key_bytes, rounds, ignore_few_rounds = False):
         # expecting this value to be slow enough (it probably would be if this
         # were bcrypt). Emit a warning.
         warnings.warn((
-            "Warning: bcrypt.kdf() called with only {} round(s). "
+            "Warning: bcrypt.kdf() called with only {0} round(s). "
             "This few is not secure: the parameter is linear, like PBKDF2.")
             .format(rounds),
             UserWarning)

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -418,6 +418,12 @@ def test_kdf_str_salt():
         )
 
 
+def test_kdf_no_warn_rounds():
+    bcrypt.kdf(
+        b"password", b"salt", 10, 10, True
+    )
+
+
 def test_kdf_warn_rounds():
     with pytest.warns(UserWarning):
         bcrypt.kdf(

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -418,6 +418,13 @@ def test_kdf_str_salt():
         )
 
 
+def test_kdf_warn_rounds():
+    with pytest.warns(UserWarning):
+        bcrypt.kdf(
+            b"password", b"salt", 10, 10
+        )
+
+
 @pytest.mark.parametrize(
     ("password", "salt", "desired_key_bytes", "rounds", "error"),
     [


### PR DESCRIPTION
Pull request as suggested for #103 