### PR TITLE
Define types and byte-order macros for Solaris.

### DIFF
--- a/src/_csrc/portable_endian.h
+++ b/src/_csrc/portable_endian.h
@@ -161,6 +161,25 @@
 #   define __LITTLE_ENDIAN LITTLE_ENDIAN
 #   define __PDP_ENDIAN    PDP_ENDIAN
 
+#elif defined(__sun)
+
+#   include <sys/byteorder.h>
+
+#   define htobe16(x) BE_16(x)
+#   define htole16(x) LE_16(x)
+#   define be16toh(x) BE_16(x)
+#   define le16toh(x) LE_16(x)
+
+#   define htobe32(x) BE_32(x)
+#   define htole32(x) LE_32(x)
+#   define be32toh(x) BE_32(x)
+#   define le32toh(x) LE_32(x)
+
+#   define htobe64(x) BE_64(x)
+#   define htole64(x) LE_64(x)
+#   define be64toh(x) BE_64(x)
+#   define le64toh(x) LE_64(x)
+
 #else
 
 #   error platform not supported

--- a/src/_csrc/pycabcrypt.h
+++ b/src/_csrc/pycabcrypt.h
@@ -14,6 +14,11 @@ typedef unsigned long long uint64_t;
 typedef uint64_t u_int64_t;
 #define snprintf _snprintf
 #define __attribute__(unused)
+#elif defined(__sun)
+typedef uint8_t u_int8_t;
+typedef uint16_t u_int16_t;
+typedef uint32_t u_int32_t;
+typedef uint64_t u_int64_t;
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
Solaris has all the needed byte-order twiddling macros built-in, but it uses different names.  Same with some of the types.  All tests pass on SPARC and x86, 32 and 64 bit.