### PR TITLE
Fixes link editing errors in msys / mingw64

### DIFF
--- a/src/_csrc/bcrypt_pbkdf.c
+++ b/src/_csrc/bcrypt_pbkdf.c
@@ -16,12 +16,12 @@
  */
 
 #include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "pycabcrypt.h"
-#include <stdlib.h>
 #include "blf.h"
 #include "sha2.h"
-#include <string.h>
 
 #define	MINIMUM(a,b) (((a) < (b)) ? (a) : (b))
 

--- a/src/_csrc/blf.h
+++ b/src/_csrc/blf.h
@@ -31,10 +31,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "pycabcrypt.h"
 
 #ifndef _BLF_H_
 #define _BLF_H_
+
+#include "pycabcrypt.h"
 
 /* Schneier states the maximum key length to be 56 bytes.
  * The way how the subkeys are initialized by the key up

--- a/src/_csrc/pycabcrypt.h
+++ b/src/_csrc/pycabcrypt.h
@@ -1,3 +1,6 @@
+#ifndef PYCABCRYPT
+#define PYCABCRYPT
+
 #include <sys/types.h>
 #include <string.h>
 #include <stdio.h>
@@ -30,3 +33,6 @@ int bcrypt_hashpass(const char *key, const char *salt, char *encrypted, size_t e
 int encode_base64(char *, const u_int8_t *, size_t);
 int timingsafe_bcmp(const void *b1, const void *b2, size_t n);
 int bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt, size_t saltlen, uint8_t *key, size_t keylen, unsigned int rounds);
+
+#endif
+


### PR DESCRIPTION
Can't compil on msys/mingw64

Error message:

build/temp.mingw-2.7/src/_csrc/bcrypt_pbkdf.o:bcrypt_pbkdf.c:(.text+0x0): multiple definition of `_abs64'
build/temp.mingw-2.7/src/_csrc/bcrypt.o:bcrypt.c:(.text+0x0): first defined here
collect2.exe: error: ld returned 1 exit status

Corrections:

    In "src/_csrc/bcrypt_pbkdf.c", re-organize:

#include <sys/types.h>
#include <stdlib.h>
#include <string.h>

#include "pycabcrypt.h"
#include "blf.h"
#include "sha2.h"

    In "src/_csrc/blf.h", move #include "pycabcrypt.h":

#ifndef BLF_H
#define BLF_H

#include "pycabcrypt.h"
...
#endif

    In "src/_csrc/pycabcrypt.h", add :

#ifndef PYCABCRYPT
#define PYCABCRYPT
...
#endif