### PR TITLE
Manage password containing NULLs

### DIFF
--- a/src/_csrc/bcrypt.c
+++ b/src/_csrc/bcrypt.c
@@ -62,13 +62,12 @@ static int decode_base64(u_int8_t *, size_t, const char *);
  * the core bcrypt function
  */
 int
-bcrypt_hashpass(const char *key, const char *salt, char *encrypted,
+bcrypt_hashpass(const char *key, size_t key_len, const char *salt, char *encrypted,
     size_t encryptedlen)
 {
 	blf_ctx state;
 	u_int32_t rounds, i, k;
 	u_int16_t j;
-	size_t key_len;
 	u_int8_t salt_len, logr, minor;
 	u_int8_t ciphertext[4 * BCRYPT_WORDS] = "OrpheanBeholderScryDoubt";
 	u_int8_t csalt[BCRYPT_MAXSALT];
@@ -88,14 +87,13 @@ bcrypt_hashpass(const char *key, const char *salt, char *encrypted,
 	/* Check for minor versions */
 	switch ((minor = salt[1])) {
 	case 'a':
-		key_len = (u_int8_t)(strlen(key) + 1);
+		key_len = (u_int8_t)(key_len + 1);
 		break;
 	case 'b':
-		/* strlen() returns a size_t, but the function calls
+		/* key_len is a size_t, but the function calls
 		 * below result in implicit casts to a narrower integer
 		 * type, so cap key_len at the actual maximum supported
 		 * length here to avoid integer wraparound */
-		key_len = strlen(key);
 		if (key_len > 72)
 			key_len = 72;
 		key_len++; /* include the NUL */

--- a/src/_csrc/pycabcrypt.h
+++ b/src/_csrc/pycabcrypt.h
@@ -29,7 +29,7 @@ typedef uint64_t u_int64_t;
 #define explicit_bzero(s,n) memset(s, 0, n)
 #define DEF_WEAK(f)
 
-int bcrypt_hashpass(const char *key, const char *salt, char *encrypted, size_t encryptedlen);
+int bcrypt_hashpass(const char *key, size_t key_len, const char *salt, char *encrypted, size_t encryptedlen);
 int encode_base64(char *, const u_int8_t *, size_t);
 int timingsafe_bcmp(const void *b1, const void *b2, size_t n);
 int bcrypt_pbkdf(const char *pass, size_t passlen, const uint8_t *salt, size_t saltlen, uint8_t *key, size_t keylen, unsigned int rounds);

--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -61,9 +61,6 @@ def hashpw(password, salt):
     if isinstance(password, six.text_type) or isinstance(salt, six.text_type):
         raise TypeError("Unicode-objects must be encoded before hashing")
 
-    if b"\x00" in password:
-        raise ValueError("password may not contain NUL bytes")
-
     # bcrypt originally suffered from a wraparound bug:
     # http://www.openwall.com/lists/oss-security/2012/01/02/4
     # This bug was corrected in the OpenBSD source by truncating inputs to 72
@@ -81,7 +78,8 @@ def hashpw(password, salt):
     original_salt, salt = salt, _normalize_re.sub(b"$2b$", salt)
 
     hashed = _bcrypt.ffi.new("char[]", 128)
-    retval = _bcrypt.lib.bcrypt_hashpass(password, salt, hashed, len(hashed))
+    retval = _bcrypt.lib.bcrypt_hashpass(password, len(password), salt,
+                                         hashed, len(hashed))
 
     if retval != 0:
         raise ValueError("Invalid salt")
@@ -99,11 +97,6 @@ def checkpw(password, hashed_password):
     if (isinstance(password, six.text_type) or
             isinstance(hashed_password, six.text_type)):
         raise TypeError("Unicode-objects must be encoded before checking")
-
-    if b"\x00" in password or b"\x00" in hashed_password:
-        raise ValueError(
-            "password and hashed_password may not contain NUL bytes"
-        )
 
     ret = hashpw(password, hashed_password)
 

--- a/src/build_bcrypt.py
+++ b/src/build_bcrypt.py
@@ -21,7 +21,7 @@ BLOWFISH_DIR = os.path.join(os.path.dirname(__file__), "_csrc")
 ffi = FFI()
 
 ffi.cdef("""
-int bcrypt_hashpass(const char *, const char *, char *, size_t);
+int bcrypt_hashpass(const char *, size_t, const char *, char *, size_t);
 int encode_base64(char *, const uint8_t *, size_t);
 int bcrypt_pbkdf(const char *, size_t, const uint8_t *, size_t,
                  uint8_t *, size_t, unsigned int);

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -146,6 +146,13 @@ _test_vectors = [
         b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.",
         b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"
     ),
+    (
+        b'}>\xb3\xfe\xf1\x8b\xa0\xe6(\xa2Lzq\xc3P\x7f\xcc\xc8b{\xf9\x14\xf6'
+        b'\xf6`\x81G5\xec\x1d\x87\x10\xbf\xa7\xe1}I7 \x96\xdfc\xf2\xbf\xb3Vh'
+        b'\xdfM\x88q\xf7\xff\x1b\x82~z\x13\xdd\xe9\x84\x00\xdd4',
+        b'$2b$10$keO.ZZs22YtygVF6BLfhGO',
+        b'$2b$10$keO.ZZs22YtygVF6BLfhGOI/JjshJYPp8DZsUtym6mJV2Eha2Hdd.'
+    )
 ]
 
 _2y_test_vectors = [
@@ -286,26 +293,6 @@ def test_hashpw_str_salt():
             b"password",
             six.text_type("$2b$04$cVWp4XaNU8a4v1uMRum2SO"),
         )
-
-
-def test_checkpw_nul_byte():
-    with pytest.raises(ValueError):
-        bcrypt.checkpw(
-            b"abc\0def",
-            b"$2b$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe"
-        )
-
-    with pytest.raises(ValueError):
-        bcrypt.checkpw(
-            b"abcdef",
-            b"$2b$04$2S\0w3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe"
-        )
-
-
-def test_hashpw_nul_byte():
-    salt = bcrypt.gensalt(4)
-    with pytest.raises(ValueError):
-        bcrypt.hashpw(b"abc\0def", salt)
 
 
 def test_checkpw_extra_data():


### PR DESCRIPTION
This patch enable the bcrypt module to handle passwords containing NUL
bytes. This is needed for passwords hashed by RT ([1]) which simply pass
the password through the SHA256 encoding, without hexifying them, and
then to bcrypt.

The native code has been modified to not use `strlen` for passwords, and
a new parameter has been added to `bcrypt_hashpass` to pass the actual
length.

[1]: https://github.com/bestpractical/rt/blob/552ebebdcd96396b8cb0b9a10d1f54ac9c7b10e0/lib/RT/User.pm#L989-L1020