### PR TITLE
Add useful trove classifiers (dev status & license)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,8 @@ setup(
     zip_safe=False,
 
     classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
The trove classifiers are displayed on PyPI and so helps inform library users about the project. Document that the project is stable and ready for use in production. Document the project is licensed under the Apache software license.