### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ bcrypt
 ======
 
 .. image:: https://img.shields.io/pypi/v/bcrypt.svg
-    :target: https://pypi.python.org/pypi/bcrypt/
+    :target: https://pypi.org/project/bcrypt/
     :alt: Latest Version
 
 .. image:: https://travis-ci.org/pyca/bcrypt.svg?branch=master


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html