### PR TITLE
Use a relative import.

### DIFF
--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -22,8 +22,7 @@ import warnings
 
 import six
 
-from bcrypt import _bcrypt
-
+from . import _bcrypt
 from .__about__ import (
     __author__, __copyright__, __email__, __license__, __summary__, __title__,
     __uri__, __version__,


### PR DESCRIPTION
Use an application relative import when importing _bcrypt.  This allows the package to work even in odd locations, such as `pip install --target . bcrypt` (rather than in the site-packages or user packages directory).