### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,7 @@ setup(
     author=__about__["__author__"],
     author_email=__about__["__email__"],
 
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[
         CFFI_DEPENDENCY,
         SIX_DEPENDENCY,


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

> If your project only runs on certain Python versions, setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440) for the Python version, used to specify the Requires-Python defined in PEP 345.