### PR TITLE
fix our CI rot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ matrix:
       env: TOXENV=py3pep8
     - language: generic
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.4
       env: TOXENV=py27
     - language: generic
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.4
       env: TOXENV=py35
 
 install: .travis/install.sh
@@ -55,3 +55,17 @@ script: .travis/run.sh
 branches:
   only:
     - master
+    - /\d+\.\d+\.x/
+    - /\d+\.\d+(\.\d+)?/
+
+notifications:
+irc:
+  channels:
+    # This is set to a secure variable to prevent forks from notifying the
+    # IRC channel whenever they fail a build. This can be removed when travis
+    # implements https://github.com/travis-ci/travis-ci/issues/1094.
+    # The value encrypted here was created via
+    # travis encrypt "irc.freenode.org#cryptography-dev"
+    - secure: "JPzgnGLaHrwuty/kp7MZVf3I4iOLNzq+ZmSmKJxwIaIpJ9rkxh65gCyMp7qoQqbpdp1KYjSgrtZ7wxEQjxljMFYRS22uTnEP2GnxRXGdC2MqhZ1+1UP0YvFuMlYDh3hx/9M6ObF/8MKrGCIlU54IIrBIYQoiEnGKyNK/snR5V9U="
+  use_notice: true
+  skip_join: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,6 @@ def configs = [
         label: 'windows64',
         toxenvs: ['py27', 'py34', 'py35', 'py36', 'py37'],
     ],
-    [
-        label: 'freebsd11',
-        toxenvs: ['py27'],
-    ],
 ]
 
 def build(label, toxenv) {

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ commands =
 
 
 [flake8]
+ignore = W504
 exclude = .tox,*.egg
 select = E,W,F,N,I
 application-import-names = bcrypt,tests


### PR DESCRIPTION
This PR:

* Updates mac image
* Will build tags on travis now
* Notifies the IRC channel for builds (so we don't miss failures like we did just now)
* Ignores flake8's W504
* Removes freebsd from our Jenkinsfile since that builder no longer exists.