### PR TITLE
add AIX platform support to portable_endian.h

### DIFF
--- a/src/_csrc/portable_endian.h
+++ b/src/_csrc/portable_endian.h
@@ -180,6 +180,35 @@
 #   define be64toh(x) BE_64(x)
 #   define le64toh(x) LE_64(x)
 
+#elif defined _AIX      /* AIX is always big endian */
+#       define be64toh(x) (x)
+#       define be32toh(x) (x)
+#       define be16toh(x) (x)
+#       define le32toh(x)                              \
+         ((((x) & 0xff) << 24) |                 \
+           (((x) & 0xff00) << 8) |                \
+           (((x) & 0xff0000) >> 8) |              \
+           (((x) & 0xff000000) >> 24))
+#       define   le64toh(x)                               \
+         ((((x) & 0x00000000000000ffL) << 56) |   \
+          (((x) & 0x000000000000ff00L) << 40) |   \
+          (((x) & 0x0000000000ff0000L) << 24) |   \
+          (((x) & 0x00000000ff000000L) << 8)  |   \
+          (((x) & 0x000000ff00000000L) >> 8)  |   \
+          (((x) & 0x0000ff0000000000L) >> 24) |   \
+          (((x) & 0x00ff000000000000L) >> 40) |   \
+          (((x) & 0xff00000000000000L) >> 56))
+#       ifndef htobe64
+#               define htobe64(x) be64toh(x)
+#       endif
+#       ifndef htobe32
+#               define htobe32(x) be32toh(x)
+#       endif
+#       ifndef htobe16
+#               define htobe16(x) be16toh(x)
+#       endif
+
+
 #else
 
 #   error platform not supported


### PR DESCRIPTION
these are changes suggested by @openmax  
resolve #119

I was able to compile/install bcrypt and paramiko on AIX