### PR TITLE
Added portable_endian support for Haiku OS

### DIFF
--- a/src/_csrc/portable_endian.h
+++ b/src/_csrc/portable_endian.h
@@ -94,6 +94,10 @@
 
 #   include <sys/endian.h>
 
+#elif defined(__HAIKU__)
+
+#   include <endian.h>
+
 #elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 #   include <sys/endian.h>


### PR DESCRIPTION
This allows the bcrypt module to be built under Haiku (https://www.haiku-os.org) and its Python3 installation. Build completes and all tests pass:

```
======================================================= test session starts ========================================================
platform haiku1 -- Python 3.6.7, pytest-4.1.1, py-1.7.0, pluggy-0.8.1
rootdir: /boot/home/git/bcrypt, inifile:
collected 145 items                                                                                                                

tests/test_bcrypt.py ....................................................................................................... [ 71%]
..........................................                                                                                   [100%]

==================================================== 145 passed in 2.29 seconds ====================================================
```