### PR TITLE
Pin the lower bound of PEP517-required setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ requires = [
     "wheel",
     "cffi>=1.1; python_implementation != 'PyPy'",
 ]
+# Point to the setuptools' PEP517 build backend explicitly to
+# disable Pip's fallback guessing
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Must be kept in sync with `setup_requirements` in `setup.py`
 requires = [
-    "setuptools",
+    "setuptools>=40.8.0",
     "wheel",
     "cffi>=1.1; python_implementation != 'PyPy'",
 ]


### PR DESCRIPTION
It fails with Pip's buggy build env isolation combined with the default fallback for the build backend which is ``setuptools.build_meta.__legacy__``.