### PR TITLE
drop python 3.4

### DIFF
--- a/.azure-pipelines/wheel-builder.yml
+++ b/.azure-pipelines/wheel-builder.yml
@@ -12,7 +12,7 @@ jobs:
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
               Python3:
-                  python.version: '3.4'
+                  python.version: '3.5'
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.7.3/python-3.7.3-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/3.7/bin/python3
       steps:
@@ -67,7 +67,7 @@ jobs:
               Python27mu:
                   PYTHON_VERSION: 'cp27-cp27mu'
               Python3m:
-                  PYTHON_VERSION: 'cp34-cp34m'
+                  PYTHON_VERSION: 'cp35-cp35m'
       steps:
           - script: /opt/python/$PYTHON_VERSION/bin/python -m virtualenv .venv
             displayName: Create virtualenv
@@ -110,14 +110,6 @@ jobs:
               Python27-x86-64:
                   containerImage: 'pyca/cryptography-runner-windows:py27-x86_64'
                   PYTHON_VERSION: '27'
-                  WINDOWS_ARCH: 'x86_64'
-              Python34-x86:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-                  PYTHON_VERSION: '34'
-                  WINDOWS_ARCH: 'x86'
-              Python34-x86-64:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-                  PYTHON_VERSION: '34'
                   WINDOWS_ARCH: 'x86_64'
               Python35-x86:
                   containerImage: 'pyca/cryptography-runner-windows:py35-x86'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27 CC=gcc
-    - python: 3.4
-      env: TOXENV=py34 CC=gcc
     - python: 3.5
       env: TOXENV=py35 CC=gcc
     - python: 3.6
@@ -26,8 +24,6 @@ matrix:
       env: TOXENV=pypy CC=gcc
     - python: 2.7
       env: TOXENV=py27 CC=clang
-    - python: 3.4
-      env: TOXENV=py34 CC=clang
     - python: 3.5
       env: TOXENV=py35 CC=clang
     - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ Compatibility
 -------------
 
 This library should be compatible with py-bcrypt and it will run on Python
-2.7, 3.4+, and PyPy 2.6+.
+2.7, 3.5+, and PyPy 2.6+.
 
 C Code
 ------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,6 @@ jobs:
       Python27:
         python.version: '2.7'
         TOXENV: py27
-      Python34:
-        python.version: '3.4'
-        TOXENV: py34
       Python35:
         python.version: '3.5'
         TOXENV: py35
@@ -27,6 +24,9 @@ jobs:
       Python37:
         python.version: '3.7'
         TOXENV: py37
+      Python38:
+        python.version: '3.8'
+        TOXENV: py38
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -52,14 +52,6 @@ jobs:
         TOXENV: py27
         containerImage: 'pyca/cryptography-runner-windows:py27-x86_64'
         PYTHON_DIR: 'Python27'
-      Python34-x86:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-        PYTHON_DIR: 'Python34'
-      Python34-x86-64:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-        PYTHON_DIR: 'Python34'
       Python35-x86:
         TOXENV: py35
         containerImage: 'pyca/cryptography-runner-windows:py35-x86'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37,py38,pep8,py3pep8,packaging
+envlist = py27,pypy,py35,py36,py37,py38,pep8,py3pep8,packaging
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
as dependencies drop 3.4 it's becoming more difficult to maintain support and 3.4 is out of support from the Python team itself.