### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,22 @@ matrix:
     - env: TOXENV=packaging
     - python: 3.5
       env: TOXENV=py3pep8
+    - python: 2.7
+      arch: arm64
+      env: TOXENV=py27 CC=gcc
+    - python: 3.8
+      arch: arm64
+      env: TOXENV=py38 CC=gcc
+      dist: xenial
+      sudo: true
+    - python: 2.7
+      arch: arm64
+      env: TOXENV=py27 CC=clang
+    - python: 3.8
+      arch: arm64
+      env: TOXENV=py38 CC=clang
+      dist: xenial
+      sudo: true
 
 install: .travis/install.sh
 


### PR DESCRIPTION
Updated travis.yml file to add ARM64 jobs in Travis-CI.
Added support for python3.7 and python3.8 for ARM64 jobs.
Resolves the first step for : #206 
@reaperhulk As per your suggestion, I have added the travis CI support for aarch64. Please review the changes.