### PR TITLE
Fix for using pip for aarch64

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -134,7 +134,7 @@ jobs:
               /opt/python/${{ matrix.PYTHON }}/bin/pip install virtualenv;
               /opt/python/${{ matrix.PYTHON }}/bin/python -m virtualenv .venv;
               .venv/bin/pip install setuptools wheel cffi six;
-              .venv/bin/pip install -U pip==10.0.1; # downgrade pip for reasons we can't remember but are definitely needed
+              .venv/bin/pip install -U pip==18.0.0; # downgrade pip for reasons we can't remember but are definitely needed
               REGEX='cp3([0-9])*';
               if [[ ${{ matrix.PYTHON }} =~ $REGEX ]]; then
                   PY_LIMITED_API=\"--build-option --py-limited-api=cp3${BASH_REMATCH[1]}\";


### PR DESCRIPTION
Updated the pip version to 18.0.0 instead of 10.0.1 for aarch64.
Resolves problem mentioned in https://github.com/pyca/bcrypt/pull/209#issuecomment-668175031 

@reaperhulk Please review and let me know if any changes required.