### PR TITLE
Drop six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from setuptools.command.test import test
 
 
 CFFI_DEPENDENCY = "cffi>=1.1"
-SIX_DEPENDENCY = "six>=1.4.1"
 
 
 CFFI_MODULES = [
@@ -54,7 +53,7 @@ setup(
     author_email=__about__["__email__"],
     python_requires=">=3.6",
     setup_requires=[CFFI_DEPENDENCY],
-    install_requires=[CFFI_DEPENDENCY, SIX_DEPENDENCY],
+    install_requires=[CFFI_DEPENDENCY],
     extras_require={"tests": ["pytest>=3.2.1,!=3.3.0"], "typecheck": ["mypy"]},
     tests_require=["pytest>=3.2.1,!=3.3.0"],
     package_dir={"": "src"},

--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -20,8 +20,6 @@ import os
 import re
 import warnings
 
-import six
-
 from . import _bcrypt  # type: ignore
 from .__about__ import (
     __author__,
@@ -76,8 +74,8 @@ def gensalt(rounds: int = 12, prefix: bytes = b"2b") -> bytes:
 
 
 def hashpw(password: bytes, salt: bytes) -> bytes:
-    if isinstance(password, six.text_type) or isinstance(salt, six.text_type):
-        raise TypeError("Unicode-objects must be encoded before hashing")
+    if isinstance(password, str) or isinstance(salt, str):
+        raise TypeError("Strings must be encoded before hashing")
 
     if b"\x00" in password:
         raise ValueError("password may not contain NUL bytes")
@@ -114,10 +112,8 @@ def hashpw(password: bytes, salt: bytes) -> bytes:
 
 
 def checkpw(password: bytes, hashed_password: bytes) -> bool:
-    if isinstance(password, six.text_type) or isinstance(
-        hashed_password, six.text_type
-    ):
-        raise TypeError("Unicode-objects must be encoded before checking")
+    if isinstance(password, str) or isinstance(hashed_password, str):
+        raise TypeError("Strings must be encoded before checking")
 
     if b"\x00" in password or b"\x00" in hashed_password:
         raise ValueError(
@@ -139,8 +135,8 @@ def kdf(
     rounds: int,
     ignore_few_rounds: bool = False,
 ) -> bytes:
-    if isinstance(password, six.text_type) or isinstance(salt, six.text_type):
-        raise TypeError("Unicode-objects must be encoded before hashing")
+    if isinstance(password, str) or isinstance(salt, str):
+        raise TypeError("Strings must be encoded before hashing")
 
     if len(password) == 0 or len(salt) == 0:
         raise ValueError("password and salt must not be empty")

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -2,8 +2,6 @@ import os
 
 import pytest
 
-import six
-
 import bcrypt
 
 
@@ -265,28 +263,28 @@ def test_checkpw_bad_salt():
 def test_checkpw_str_password():
     with pytest.raises(TypeError):
         bcrypt.checkpw(
-            six.text_type("password"), b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
+            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
         )
 
 
 def test_checkpw_str_salt():
     with pytest.raises(TypeError):
         bcrypt.checkpw(
-            b"password", six.text_type("$2b$04$cVWp4XaNU8a4v1uMRum2SO"),
+            b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO",
         )
 
 
 def test_hashpw_str_password():
     with pytest.raises(TypeError):
         bcrypt.hashpw(
-            six.text_type("password"), b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
+            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
         )
 
 
 def test_hashpw_str_salt():
     with pytest.raises(TypeError):
         bcrypt.hashpw(
-            b"password", six.text_type("$2b$04$cVWp4XaNU8a4v1uMRum2SO"),
+            b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO",
         )
 
 
@@ -441,13 +439,13 @@ def test_kdf(rounds, password, salt, expected):
 def test_kdf_str_password():
     with pytest.raises(TypeError):
         bcrypt.kdf(
-            six.text_type("password"), b"$2b$04$cVWp4XaNU8a4v1uMRum2SO", 10, 10
+            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO", 10, 10
         )
 
 
 def test_kdf_str_salt():
     with pytest.raises(TypeError):
-        bcrypt.kdf(b"password", six.text_type("salt"), 10, 10)
+        bcrypt.kdf(b"password", "salt", 10, 10)
 
 
 def test_kdf_no_warn_rounds():

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -262,30 +262,22 @@ def test_checkpw_bad_salt():
 
 def test_checkpw_str_password():
     with pytest.raises(TypeError):
-        bcrypt.checkpw(
-            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
-        )
+        bcrypt.checkpw("password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO")
 
 
 def test_checkpw_str_salt():
     with pytest.raises(TypeError):
-        bcrypt.checkpw(
-            b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO",
-        )
+        bcrypt.checkpw(b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO")
 
 
 def test_hashpw_str_password():
     with pytest.raises(TypeError):
-        bcrypt.hashpw(
-            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO",
-        )
+        bcrypt.hashpw("password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO")
 
 
 def test_hashpw_str_salt():
     with pytest.raises(TypeError):
-        bcrypt.hashpw(
-            b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO",
-        )
+        bcrypt.hashpw(b"password", "$2b$04$cVWp4XaNU8a4v1uMRum2SO")
 
 
 def test_checkpw_nul_byte():
@@ -438,9 +430,7 @@ def test_kdf(rounds, password, salt, expected):
 
 def test_kdf_str_password():
     with pytest.raises(TypeError):
-        bcrypt.kdf(
-            "password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO", 10, 10
-        )
+        bcrypt.kdf("password", b"$2b$04$cVWp4XaNU8a4v1uMRum2SO", 10, 10)
 
 
 def test_kdf_str_salt():


### PR DESCRIPTION
Since python 2 support is dropped, six dependency can be dropped as well.
`text_type` is `str` in Python 3: https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/six.py#L44

I also modified exception message slightly, this might be a breaking change. Please tell me if I should change it back.