### PR TITLE
fix page size on aarch64

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -112,6 +112,9 @@ jobs:
       - uses: docker://quay.io/pypa/manylinux2014_aarch64
         # The weird pip cache nonsense below is due to docker ownership issues. We want
         # a cache because otherwise we end up building cffi twice.
+        # The bizarro max-page-size linker flag is to enforce 64k alignment even on 4k
+        # systems so we don't get ELF load command alignment not page-aligned on 64k
+        # systems.
         with:
           args: |
               bash -c "set -xe;
@@ -123,7 +126,7 @@ jobs:
               tar zxvf bcrypt*.tar.gz;
               mkdir tmpwheelhouse;
               pushd bcrypt*;
-              ../.venv/bin/python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }};
+              CFLAGS=\"-Wl,-z,max-page-size=0x10000\" ../.venv/bin/python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }};
               mv dist/bcrypt*.whl ../tmpwheelhouse;
               popd;
               auditwheel repair tmpwheelhouse/bcrypt*.whl -w wheelhouse/;


### PR DESCRIPTION
debian/ubuntu use 4k pages while centos uses 64k pages. 64k pages work
on 4k page systems while a 4k compiled binary will throw this error:
ELF load command alignment not page-aligned

This patch attempts to pass a linker flag that should force 64k page
alignment at all times

Sample run: https://github.com/pyca/bcrypt/runs/993847721?check_suite_focus=true