### PR TITLE
Fix security policy link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Security
 ``bcrypt`` follows the `same security policy as cryptography`_, if you
 identify a vulnerability, we ask you to contact us privately.
 
-.. _`same security policy as cryptography`: https://cryptography.io/en/latest/security/
+.. _`same security policy as cryptography`: https://cryptography.io/en/latest/security.html
 .. _`standard library`: https://docs.python.org/3/library/hashlib.html#hashlib.scrypt
 .. _`argon2_cffi`: https://argon2-cffi.readthedocs.io
 .. _`cryptography`: https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions/#cryptography.hazmat.primitives.kdf.scrypt.Scrypt


### PR DESCRIPTION
Trivial documentation fix, just replacing the link to the Cryptography security policy to avoid confusion when users like me reach a 404 page.

Based on the Wayback Machine, looks like this page move was sometime between October 20, 2020 and November 26, 2020.