### PR TITLE
Installing bcrypt on z/OS

### DIFF
--- a/src/_csrc/portable_endian.h
+++ b/src/_csrc/portable_endian.h
@@ -212,6 +212,22 @@
 #               define htobe16(x) be16toh(x)
 #       endif
 
+#elif defined(__s390x__)
+#       include <arpa/inet.h>
+#       define htobe16(x) htons(x)
+#       define htole16(x) (x)
+#       define be16toh(x) ntohs(x)
+#       define le16toh(x) (x)
+	
+#       define htobe32(x) htonl(x)
+#       define htole32(x) (x)
+#       define be32toh(x) ntohl(x)
+#       define le32toh(x) (x)
+	
+#       define htobe64(x) (((uint64_t)htonl(((uint32_t)(((uint64_t)(x)) >> 32)))) | (((uint64_t)htonl(((uint32_t)(x)))) << 32))
+#       define htole64(x) (x)
+#       define be64toh(x) (((uint64_t)ntohl(((uint32_t)(((uint64_t)(x)) >> 32)))) | (((uint64_t)ntohl(((uint32_t)(x)))) << 32))
+#       define le64toh(x) (x)
 
 #else
 

--- a/src/_csrc/pycabcrypt.h
+++ b/src/_csrc/pycabcrypt.h
@@ -22,6 +22,12 @@ typedef uint8_t u_int8_t;
 typedef uint16_t u_int16_t;
 typedef uint32_t u_int32_t;
 typedef uint64_t u_int64_t;
+#elif defined(__s390x__)
+#include <stdint.h>
+typedef uint8_t u_int8_t;
+typedef uint16_t u_int16_t;
+typedef uint32_t u_int32_t;
+typedef uint64_t u_int64_t;
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
These changes allow z/OS users to install bcrypt. 

It originally fell into an error statement saying the “platform not supported”.
Defining needed macros and types resolves the errors. 
