### PR TITLE
Installing bcrypt on z/OS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Changelog
 
 UNRELEASED
 ----------
-
+* Added support for compilation on z/OS
 
 3.2.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Changelog
 
 UNRELEASED
 ----------
+
 * Added support for compilation on z/OS
 
 3.2.0

--- a/src/_csrc/portable_endian.h
+++ b/src/_csrc/portable_endian.h
@@ -212,6 +212,22 @@
 #               define htobe16(x) be16toh(x)
 #       endif
 
+#elif defined(__MVS__)
+
+#           define htobe16(x) (x)
+#           define htole16(x) (((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
+#           define be16toh(x) (x)
+#           define le16toh(x) (((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
+
+#           define htobe32(x) (x)
+#           define htole32(x) (((uint32_t)htole16(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)htole16(((uint16_t)(x)))) << 16))
+#           define be32toh(x) (x)
+#           define le32toh(x) (((uint32_t)le16toh(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)le16toh(((uint16_t)(x)))) << 16))
+
+#           define htobe64(x) (x)
+#           define htole64(x) (((uint64_t)htole32(((uint32_t)(((uint64_t)(x)) >> 32)))) | (((uint64_t)htole32(((uint32_t)(x)))) << 32))
+#           define be64toh(x) (x)
+#           define le64toh(x) (((uint64_t)le32toh(((uint32_t)(((uint64_t)(x)) >> 32)))) | (((uint64_t)le32toh(((uint32_t)(x)))) << 32))
 
 #else
 

--- a/src/_csrc/pycabcrypt.h
+++ b/src/_csrc/pycabcrypt.h
@@ -22,6 +22,12 @@ typedef uint8_t u_int8_t;
 typedef uint16_t u_int16_t;
 typedef uint32_t u_int32_t;
 typedef uint64_t u_int64_t;
+#elif defined(__MVS__)
+#include <stdint.h>
+typedef uint8_t u_int8_t;
+typedef uint16_t u_int16_t;
+typedef uint32_t u_int32_t;
+typedef uint64_t u_int64_t;
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
These changes allow z/OS users to install bcrypt.

It originally fell into an error statement saying “platform not supported”.
Defining needed macros and types resolves the errors. 
All tests passed. 