### PR TITLE
Revert "Bump actions/upload-artifact from 1 to 2.2.3"

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: mkdir bcrypt-wheelhouse
       - run: mv wheelhouse/bcrypt*.whl bcrypt-wheelhouse/
-      - uses: actions/upload-artifact@v2.2.3
+      - uses: actions/upload-artifact@v1
         with:
           name: "bcrypt-${{ github.event.inputs.version }}-${{ matrix.CONTAINER.NAME }} -${{ matrix.PYTHON.ABI_VERSION }}"
           path: bcrypt-wheelhouse/
@@ -60,7 +60,7 @@ jobs:
 
       - run: mkdir bcrypt-wheelhouse
       - run: mv wheelhouse/bcrypt*.whl bcrypt-wheelhouse/
-      - uses: actions/upload-artifact@v2.2.3
+      - uses: actions/upload-artifact@v1
         with:
           name: "bcrypt-${{ github.event.inputs.version }}-macOS-${{ matrix.PYTHON.ABI_VERSION }}"
           path: bcrypt-wheelhouse/
@@ -93,7 +93,7 @@ jobs:
       # TODO: can we setup another python and test in the same job? this would catch bad linking problems (e.g. build and test on py36, but then install py38 and see if it works
       - run: mkdir bcrypt-wheelhouse
       - run: move wheelhouse\bcrypt*.whl bcrypt-wheelhouse\
-      - uses: actions/upload-artifact@v2.2.3
+      - uses: actions/upload-artifact@v1
         with:
           name: "bcrypt-${{ github.event.inputs.version }}-${{ matrix.WINDOWS }}-${{ matrix.PYTHON.ABI_VERSION }}"
           path: bcrypt-wheelhouse\
@@ -131,7 +131,7 @@ jobs:
               .venv/bin/python -c \"import bcrypt; password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());bcrypt.checkpw(password, hashed)\";"
       - run: mkdir bcrypt-wheelhouse
       - run: sudo mv wheelhouse/bcrypt*.whl bcrypt-wheelhouse/
-      - uses: actions/upload-artifact@v2.2.3
+      - uses: actions/upload-artifact@v1
         with:
           name: "bcrypt-${{ github.event.inputs.version }}-manylinux2014-aarch64-${{ matrix.PYTHON.ABI_VERSION }}"
           path: bcrypt-wheelhouse/


### PR DESCRIPTION
Reverts pyca/bcrypt#256

We can't bump the `upload-artifact` version used in manylinux wheels because of libc shenangins.