### PR TITLE
python-six uneeded to build wheels

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - run: /opt/python/${{ matrix.PYTHON.VERSION }}/bin/python -m venv .venv
       - name: Install python dependencies
-        run: .venv/bin/pip install -U pip wheel cffi six
+        run: .venv/bin/pip install -U pip wheel cffi
       - run: .venv/bin/pip download bcrypt==${{ github.event.inputs.version }} --no-deps --no-binary bcrypt && tar zxvf bcrypt*.tar.gz && mkdir tmpwheelhouse
       - run: cd bcrypt* && ../.venv/bin/python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/bcrypt*.whl ../tmpwheelhouse
       - run: auditwheel repair tmpwheelhouse/bcrypt*.whl -w wheelhouse/
@@ -51,7 +51,7 @@ jobs:
           curl "${{ matrix.PYTHON.DOWNLOAD_URL }}" -o python.pkg
           sudo installer -pkg python.pkg -target /
       - run: ${{ matrix.PYTHON.BIN_PATH }} -m venv venv
-      - run: venv/bin/pip install -U pip wheel cffi six
+      - run: venv/bin/pip install -U pip wheel cffi
       - run: venv/bin/pip download bcrypt==${{ github.event.inputs.version }} --no-deps --no-binary bcrypt && tar zxvf bcrypt*.tar.gz && mkdir wheelhouse
       - run: cd bcrypt* && ../venv/bin/python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/bcrypt*.whl ../wheelhouse
       - run: venv/bin/pip install -f wheelhouse --no-index bcrypt
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS }}
-      - run: python -m pip install -U pip wheel cffi six
+      - run: python -m pip install -U pip wheel cffi
       - run: pip download bcrypt==${{ github.event.inputs.version }} --no-deps --no-binary bcrypt && tar zxvf bcrypt*.tar.gz && mkdir wheelhouse
         shell: bash
       - run: cd bcrypt* && python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/bcrypt*.whl ../wheelhouse
@@ -118,7 +118,7 @@ jobs:
               mkdir -p /github/home/.cache/pip;
               chown -R $(whoami) /github/home/.cache;
               /opt/python/${{ matrix.PYTHON.VERSION }}/bin/python -m venv .venv;
-              .venv/bin/pip install -U pip wheel cffi six;
+              .venv/bin/pip install -U pip wheel cffi;
               .venv/bin/pip download bcrypt==${{ github.event.inputs.version }} --no-deps --no-binary bcrypt;
               tar zxvf bcrypt*.tar.gz;
               mkdir tmpwheelhouse;


### PR DESCRIPTION
Python-six has been removed from the dependencies with https://github.com/pyca/bcrypt/pull/225. So I guess it's not needed by the worker too.

*I did not check if the patch works**because I don't think I can run it.