### PR TITLE
Replace the `cryptography` mention in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
         """
         =============================DEBUG ASSISTANCE==========================
         If you are seeing an error here please try the following to
-        successfully install cryptography:
+        successfully install bcrypt:
 
         Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip


### PR DESCRIPTION
This typo was introduced in:
* https://github.com/pyca/bcrypt/pull/395/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R17
* https://github.com/pyca/bcrypt/commit/eceb9797#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R17

It seems to have been copied from
https://github.com/pyca/cryptography/commit/ab537a61#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R20