### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39"}
           - {VERSION: "3.10", TOXENV: "py310"}
           - {VERSION: "3.11", TOXENV: "py311"}
+          - {VERSION: "3.12-dev", TOXENV: "py312"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3"}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
To match https://github.com/pyca/cryptography (re: https://github.com/pyca/cryptography/pull/9506), I only added 3.12 to the test matrix for Ubuntu.

(I did check the tests for macOS and Windows with 3.12, and they all pass :tada:, but it's not included here: https://github.com/hugovk/bcrypt/actions/runs/6130920348/job/16640467738)

