### PR TITLE
Bump version for 4.2.1

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -32,6 +32,14 @@ jobs:
       - run: echo "$EVENT_CONTEXT"
         env:
           EVENT_CONTEXT: ${{ toJson(github.event) }}
+
+      - run: |
+          echo "PYPI_URL=https://upload.pypi.org/legacy/" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
+      - run: |
+          echo "PYPI_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
+
       - uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           path: tmpdist/
@@ -40,15 +48,8 @@ jobs:
       - run: |
           find tmpdist/ -type f -name 'bcrypt*' -exec mv {} dist/ \;
 
-      - run: |
-          echo "PYPI_URL=https://pypi.org/legacy/" >> $GITHUB_ENV
-        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
-      - run: |
-          echo "PYPI_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
-
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc  # v1.12.2
         with:
           repository-url: ${{ env.PYPI_URL }}
           skip-existing: true
@@ -56,4 +57,4 @@ jobs:
           # because there's nothing that would prevent a malicious PyPI from
           # serving a signed TestPyPI asset in place of a release intended for
           # PyPI.
-          attestations: ${{ env.PYPI_URL == 'https://pypi.org/legacy/' }}
+          attestations: ${{ env.PYPI_URL == 'https://upload.pypi.org/legacy/' }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -49,7 +49,6 @@ jobs:
         PYTHON:
           - { VERSION: "cp37-cp37m", ABI_VERSION: 'cp37' }
           - { VERSION: "cp39-cp39", ABI_VERSION: 'cp39' }
-          - { VERSION: "pp39-pypy39_pp73" }
           - { VERSION: "pp310-pypy310_pp73" }
         MANYLINUX:
           - { NAME: "manylinux2014_x86_64", CONTAINER: "cryptography-manylinux2014:x86_64", RUNNER: "ubuntu-latest" }
@@ -63,31 +62,19 @@ jobs:
           - { NAME: "musllinux_1_2_aarch64", CONTAINER: "cryptography-musllinux_1_2:aarch64", RUNNER: [self-hosted, Linux, ARM64]}
         exclude:
           # There are no readily available musllinux PyPy distributions
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64", RUNNER: "ubuntu-latest"}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64", RUNNER: "ubuntu-latest"}
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "musllinux_1_1_aarch64", CONTAINER: "cryptography-musllinux_1_1:aarch64", RUNNER: [self-hosted, Linux, ARM64]}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "musllinux_1_1_aarch64", CONTAINER: "cryptography-musllinux_1_1:aarch64", RUNNER: [self-hosted, Linux, ARM64]}
 
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "musllinux_1_2_x86_64", CONTAINER: "cryptography-musllinux_1_2:x86_64", RUNNER: "ubuntu-latest"}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "musllinux_1_2_x86_64", CONTAINER: "cryptography-musllinux_1_2:x86_64", RUNNER: "ubuntu-latest"}
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "musllinux_1_2_aarch64", CONTAINER: "cryptography-musllinux_1_2:aarch64", RUNNER: [self-hosted, Linux, ARM64]}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "musllinux_1_2_aarch64", CONTAINER: "cryptography-musllinux_1_2:aarch64", RUNNER: [self-hosted, Linux, ARM64]}
 
             # We also don't build pypy wheels for anything except the latest manylinux
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "manylinux2014_x86_64", CONTAINER: "cryptography-manylinux2014:x86_64", RUNNER: "ubuntu-latest"}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "manylinux2014_x86_64", CONTAINER: "cryptography-manylinux2014:x86_64", RUNNER: "ubuntu-latest"}
-          - PYTHON: { VERSION: "pp39-pypy39_pp73" }
-            MANYLINUX: { NAME: "manylinux2014_aarch64", CONTAINER: "cryptography-manylinux2014_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
           - PYTHON: { VERSION: "pp310-pypy310_pp73" }
             MANYLINUX: { NAME: "manylinux2014_aarch64", CONTAINER: "cryptography-manylinux2014_aarch64", RUNNER: [self-hosted, Linux, ARM64]}
     name: "${{ matrix.PYTHON.VERSION }} for ${{ matrix.MANYLINUX.NAME }}"

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,13 @@ While bcrypt remains an acceptable choice for password storage, depending on you
 Changelog
 =========
 
+4.2.1
+-----
+
+* Bump Rust dependency versions - this should resolve crashes on Python 3.13
+  free-threaded builds.
+* We no longer build ``manylinux`` wheels for PyPy 3.9.
+
 4.2.0
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "bcrypt"
 # When updating this, also update lib.rs
-version = "4.2.0"
+version = "4.2.1"
 authors = [
     {name = "The Python Cryptographic Authority developers", email = "cryptography-dev@python.org"}
 ]

--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -197,7 +197,7 @@ mod _bcrypt {
         // When updating this, also update pyproject.toml
         // This isn't named __version__ because passlib treats the existence of
         // that attribute as proof that we're a different module
-        m.add("__version_ex__", "4.2.0")?;
+        m.add("__version_ex__", "4.2.1")?;
 
         let author = "The Python Cryptographic Authority developers";
         m.add("__author__", author)?;


### PR DESCRIPTION
Backports fixes to pypi-publish from cryptography.

refs #913