### PR TITLE
Support free-threaded Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         PYTHON:
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
+          - {VERSION: "3.13t", TOXENV: "py313t"}
         MACOS:
           - macos-13
           - macos-latest
@@ -24,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v5.3.0
+        uses: quansight-labs/setup-python@v5.3.1
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
       - uses: actions/cache@v4.2.0
@@ -53,12 +54,13 @@ jobs:
         PYTHON:
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
+          - {VERSION: "3.13t", TOXENV: "py313t"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}"
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v5.3.0
+        uses: quansight-labs/setup-python@v5.3.1
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}
@@ -92,6 +94,7 @@ jobs:
           - {VERSION: "3.11", TOXENV: "py311"}
           - {VERSION: "3.12", TOXENV: "py312"}
           - {VERSION: "3.13", TOXENV: "py313"}
+          - {VERSION: "3.13", TOXENV: "py313t"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3"}
 
@@ -104,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@v5.3.0
+        uses: quansight-labs/setup-python@v5.3.1
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
       - uses: actions/cache@v4.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         PYTHON:
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
-          - {VERSION: "3.13t", TOXENV: "py313t"}
+          - {VERSION: "3.13t", TOXENV: "py313"}
         MACOS:
           - macos-13
           - macos-latest
@@ -54,7 +54,7 @@ jobs:
         PYTHON:
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
-          - {VERSION: "3.13t", TOXENV: "py313t"}
+          - {VERSION: "3.13t", TOXENV: "py313"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}"
     steps:
       - uses: actions/checkout@v4.2.2
@@ -94,7 +94,7 @@ jobs:
           - {VERSION: "3.11", TOXENV: "py311"}
           - {VERSION: "3.12", TOXENV: "py312"}
           - {VERSION: "3.13", TOXENV: "py313"}
-          - {VERSION: "3.13", TOXENV: "py313t"}
+          - {VERSION: "3.13t", TOXENV: "py313"}
           - {VERSION: "pypy-3.9", TOXENV: "pypy3"}
           - {VERSION: "pypy-3.10", TOXENV: "pypy3"}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           - {VERSION: "3.13", TOXENV: "py313", RUST_VERSION: "1.64.0"}
           - {VERSION: "3.13", TOXENV: "py313", RUST_VERSION: "beta"}
           - {VERSION: "3.13", TOXENV: "py313", RUST_VERSION: "nightly"}
-    name: "${{ matrix.PYTHON.TOXENV }} on linux, Rust ${{ matrix.PYTHON.RUST_VERSION || 'stable' }}"
+    name: "${{ matrix.PYTHON.VERSION }} on linux, Rust ${{ matrix.PYTHON.RUST_VERSION || 'stable' }}"
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup python

--- a/README.rst
+++ b/README.rst
@@ -285,7 +285,7 @@ Compatibility
 -------------
 
 This library should be compatible with py-bcrypt and it will run on Python
-3.6+, and PyPy 3.
+3.8+ (including free-threaded builds), and PyPy 3.
 
 Security
 --------

--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -182,7 +182,7 @@ fn kdf<'p>(
     })
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 mod _bcrypt {
     use pyo3::types::PyModuleMethods;
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -1,11 +1,9 @@
-import random
 import uuid
-
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+
+import pytest
 
 import bcrypt
-import pytest
 
 _test_vectors = [
     (
@@ -519,9 +517,9 @@ def test_multithreading():
             return bcrypt.checkpw(pw, self.hash_)
 
     # use UUIDs as both ID and passwords
-    NUM_USERS = 50
-    ids = [get_id() for _ in range(NUM_USERS)]
-    pws = {id_: get_id() for id_, _ in zip(ids, range(NUM_USERS))}
+    num_users = 50
+    ids = [get_id() for _ in range(num_users)]
+    pws = {id_: get_id() for id_, _ in zip(ids, range(num_users))}
 
     user_creator = ThreadPoolExecutor(max_workers=4)
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -467,6 +467,7 @@ def test_kdf_no_warn_rounds():
     bcrypt.kdf(b"password", b"salt", 10, 10, True)
 
 
+# Python warning state is global
 @pytest.mark.thread_unsafe()
 def test_kdf_warn_rounds():
     with pytest.warns(UserWarning):
@@ -500,7 +501,8 @@ def test_2a_wraparound_bug():
     )
 
 
-@pytest.mark.thread_unsafe()
+# this test spawns threads and is slow, so don't run it in many threads
+@pytest.mark.parallel_threads(1)
 def test_multithreading():
     def get_id():
         return uuid.uuid4().bytes

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -527,7 +527,8 @@ def test_multithreading():
         return id_, User(id_, pw)
 
     creator_futures = [
-        user_creator.submit(create_user, id_, pw) for id_, pw in pws.items()]
+        user_creator.submit(create_user, id_, pw) for id_, pw in pws.items()
+    ]
 
     users = [future.result() for future in creator_futures]
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -464,6 +464,7 @@ def test_kdf_no_warn_rounds():
     bcrypt.kdf(b"password", b"salt", 10, 10, True)
 
 
+@pytest.mark.thread_unsafe()
 def test_kdf_warn_rounds():
     with pytest.warns(UserWarning):
         bcrypt.kdf(b"password", b"salt", 10, 10)

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -467,8 +467,6 @@ def test_kdf_no_warn_rounds():
     bcrypt.kdf(b"password", b"salt", 10, 10, True)
 
 
-# Python warning state is global
-@pytest.mark.thread_unsafe()
 def test_kdf_warn_rounds():
     with pytest.warns(UserWarning):
         bcrypt.kdf(b"password", b"salt", 10, 10)
@@ -501,8 +499,6 @@ def test_2a_wraparound_bug():
     )
 
 
-# this test spawns threads and is slow, so don't run it in many threads
-@pytest.mark.parallel_threads(1)
 def test_multithreading():
     def create_user(pw):
         salt = bcrypt.gensalt(4)

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,11 @@ extras =
     tests
 deps =
     coverage
+    pytest-run-parallel
 passenv =
     RUSTUP_HOME
 commands =
-    coverage run -m pytest --strict-markers {posargs}
+    coverage run -m pytest --parallel-threads=10 --strict-markers {posargs}
     coverage combine
     coverage report -m --fail-under 100
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,10 @@ extras =
     tests
 deps =
     coverage
-    pytest-run-parallel
 passenv =
     RUSTUP_HOME
 commands =
-    coverage run -m pytest --parallel-threads=10 --strict-markers {posargs}
+    coverage run -m pytest --strict-markers {posargs}
     coverage combine
     coverage report -m --fail-under 100
 


### PR DESCRIPTION
Towards fixing #913.

* Adds [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel) as a test dependency. This does a good job of detecting thread-unsafe use of global state but doesn't catch thread safety issues due to sharing mutable state stored in objects. I marked one test as thread-unsafe because it uses the `warnings` module, which isn't thread-safe.

* Declares that the rust PyO3 module exprted in `_bcrypt` doesn't use the GIL. It looks like the rust code exports python functions and doesn't define any objects with state. Am I missing something?

* Sets up free-threaded CI using [quansight-labs/setup-python](https://github.com/Quansight-Labs/setup-python).

It looks like the existing tests don't use `threading` at all. Should I add some multithreaded tests? Or is `pytest-run-parallel` executing the existing tests in parallel sufficient?

After this I'll look at updating the wheel-building and uploading 313t wheels.