### PR TITLE
drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         PYTHON:
-          - {VERSION: "3.7", TOXENV: "py37"}
+          - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
         MACOS:
           - macos-13
           - macos-latest
-        exclude:
-          # We only test latest Python on arm64. py37 won't work since there's
-          # no universal2 binary
-          - PYTHON: {VERSION: "3.7", TOXENV: "py37"}
-            MACOS: macos-latest
     name: "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.MACOS }}"
     steps:
       - uses: actions/checkout@v4.2.2
@@ -56,7 +51,7 @@ jobs:
           - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
           - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc'}
         PYTHON:
-          - {VERSION: "3.7", TOXENV: "py37"}
+          - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.13", TOXENV: "py313"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}"
     steps:
@@ -91,7 +86,6 @@ jobs:
         PYTHON:
           - {VERSION: "3.13", TOXENV: "pep8,packaging"}
           - {VERSION: "3.13", TOXENV: "mypy"}
-          - {VERSION: "3.7", TOXENV: "py37"}
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.9", TOXENV: "py39"}
           - {VERSION: "3.10", TOXENV: "py310"}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         PYTHON:
-          - { VERSION: "cp37-cp37m", ABI_VERSION: 'cp37' }
+          - { VERSION: "cp38-cp38", ABI_VERSION: 'cp38' }
           - { VERSION: "cp39-cp39", ABI_VERSION: 'cp39' }
           - { VERSION: "pp310-pypy310_pp73" }
         MANYLINUX:
@@ -132,7 +132,7 @@ jobs:
       matrix:
         PYTHON:
           - VERSION: '3.11'
-            ABI_VERSION: 'cp37'
+            ABI_VERSION: 'cp38'
             DOWNLOAD_URL: 'https://www.python.org/ftp/python/3.11.3/python-3.11.3-macos11.pkg'
             BIN_PATH: '/Library/Frameworks/Python.framework/Versions/3.11/bin/python3'
           - VERSION: '3.11'
@@ -188,7 +188,7 @@ jobs:
           - {ARCH: 'x86', RUST_TRIPLE: 'i686-pc-windows-msvc'}
           - {ARCH: 'x64', RUST_TRIPLE: 'x86_64-pc-windows-msvc'}
         PYTHON:
-          - {VERSION: "3.11", ABI_VERSION: "cp37"}
+          - {VERSION: "3.11", ABI_VERSION: "cp38"}
           - {VERSION: "3.11", ABI_VERSION: "cp39"}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.PYTHON.ABI_VERSION }} ${{ matrix.WINDOWS.ARCH }}"
     steps:

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,11 @@ While bcrypt remains an acceptable choice for password storage, depending on you
 Changelog
 =========
 
+Unreleased
+----------
+
+* Dropped support for Python 3.7.
+
 4.2.1
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -32,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 dynamic = ["readme"]
 
 [project.urls]


### PR DESCRIPTION
per https://github.com/pyca/bcrypt/pull/925#issuecomment-2498951144

Reading over https://github.com/pyca/bcrypt/issues/694 I *think* just moving the cp37m wheel builds to be cp38 is sufficient and bcrypt does still need two wheel builds to work around the ceph/subinterpreter issue.