### PR TITLE
include matrix.PYTHON.VERSION in CI cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/_bcrypt/target/
-          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION  }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: pip install nox
       - run: nox -v
         env:
@@ -74,7 +74,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/_bcrypt/target/
-          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ matrix.PYTHON.VERSION  }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: pip install nox
       - run: nox -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/_bcrypt/target/
-          key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION  }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: pip install nox
       - run: nox -v
         env:
@@ -74,7 +74,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/_bcrypt/target/
-          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ matrix.PYTHON.VERSION  }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: pip install nox
       - run: nox -v


### PR DESCRIPTION
This is an attempt to unblock CI. The Linux CI already includes this in the cache key.

See https://github.com/pyca/bcrypt/pull/960#issuecomment-2622656272