### PR TITLE
Raise ValueError if password is longer than 72 bytes

### DIFF
--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -89,8 +89,6 @@ fn hashpw<'p>(
         ));
     }
 
-    let password = &password[..password.len()];
-
     // salt here is not just the salt bytes, but rather an encoded value
     // containing a version number, number of rounds, and the salt.
     // Should be [prefix, cost, hash]. This logic is copied from `bcrypt`

--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -78,7 +78,18 @@ fn hashpw<'p>(
     // bytes on the updated prefix $2b$, but leaving $2a$ unchanged for
     // compatibility. However, pyca/bcrypt 2.0.0 *did* correctly truncate inputs
     // on $2a$, so we do it here to preserve compatibility with 2.0.0
-    let password = &password[..password.len().min(72)];
+    // Silent truncation is _probably_ not the best idea, even if the "original" 
+    // OpenBSD implementation did/does this.
+    // We prefer to raise a ValueError in this case - if the user _wants_ to truncate,
+    // they can always do so manually by passing s[:72] instead of s into hashpw().
+
+    if password.len() > 72 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Password cannot be longer than 72 bytes",
+        ));
+    }
+
+    let password = &password[..password.len()];
 
     // salt here is not just the salt bytes, but rather an encoded value
     // containing a version number, number of rounds, and the salt.

--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -78,14 +78,14 @@ fn hashpw<'p>(
     // bytes on the updated prefix $2b$, but leaving $2a$ unchanged for
     // compatibility. However, pyca/bcrypt 2.0.0 *did* correctly truncate inputs
     // on $2a$, so we do it here to preserve compatibility with 2.0.0
-    // Silent truncation is _probably_ not the best idea, even if the "original" 
+    // Silent truncation is _probably_ not the best idea, even if the "original"
     // OpenBSD implementation did/does this.
     // We prefer to raise a ValueError in this case - if the user _wants_ to truncate,
     // they can always do so manually by passing s[:72] instead of s into hashpw().
 
     if password.len() > 72 {
         return Err(pyo3::exceptions::PyValueError::new_err(
-            "Password cannot be longer than 72 bytes",
+            "password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])",
         ));
     }
 

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -155,25 +155,6 @@ _2y_test_vectors = [
     ),
 ]
 
-_long_pw_vectors = [
-    (
-        b"0123456789abcdefghijklmnopqrstuvwxyz"
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        b"chars after 72 are ignored",
-        b"$2a$05$abcdefghijklmnopqrstuu",
-    ),
-    (
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"chars after 72 are ignored as usual",
-        b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.",
-    ),
-]
-
 
 def test_gensalt_basic():
     salt = bcrypt.gensalt()
@@ -251,12 +232,6 @@ def test_hashpw_2y_prefix(password, hashed, expected):
 @pytest.mark.parametrize(("password", "hashed", "expected"), _2y_test_vectors)
 def test_checkpw_2y_prefix(password, hashed, expected):
     assert bcrypt.checkpw(password, hashed) is True
-
-
-@pytest.mark.parametrize(("password", "salt"), _long_pw_vectors)
-def test_hashpw_raises_on_passwords_longer_than_72_chars(password, salt):
-    with pytest.raises(ValueError):
-        bcrypt.hashpw(password, salt)
 
 
 @pytest.mark.parametrize(
@@ -514,11 +489,6 @@ def test_kdf_warn_rounds():
 def test_invalid_params(password, salt, desired_key_bytes, rounds, error):
     with pytest.raises(error):
         bcrypt.kdf(password, salt, desired_key_bytes, rounds)
-
-
-def test_2a_wraparound_bug():
-    with pytest.raises(ValueError):
-        bcrypt.hashpw((b"0123456789" * 26)[:255], b"$2a$04$R1lJ2gkNaoPGdafE.H.16.")
 
 
 def test_multithreading():

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -517,12 +517,8 @@ def test_invalid_params(password, salt, desired_key_bytes, rounds, error):
 
 
 def test_2a_wraparound_bug():
-    assert (
-        bcrypt.hashpw(
-            (b"0123456789" * 26)[:255], b"$2a$04$R1lJ2gkNaoPGdafE.H.16."
-        )
-        == b"$2a$04$R1lJ2gkNaoPGdafE.H.16.1MKHPvmKwryeulRe225LKProWYwt9Oi"
-    )
+    with pytest.raises(ValueError):
+        bcrypt.hashpw((b"0123456789" * 26)[:255], b"$2a$04$R1lJ2gkNaoPGdafE.H.16.")
 
 
 def test_multithreading():

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -122,24 +122,6 @@ _test_vectors = [
         b"$2a$05$XXXXXXXXXXXXXXXXXXXXXOAcXxm9kjPGEMsLznoKqmqw7tc8WCx4a",
     ),
     (
-        b"0123456789abcdefghijklmnopqrstuvwxyz"
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        b"chars after 72 are ignored",
-        b"$2a$05$abcdefghijklmnopqrstuu",
-        b"$2a$05$abcdefghijklmnopqrstuu5s2v8.iXieOjg/.AySBTTZIIVFJeBui",
-    ),
-    (
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
-        b"chars after 72 are ignored as usual",
-        b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.",
-        b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.swQOIzjOiJ9GHEPuhEkvqrUyvWhEMx6",
-    ),
-    (
         b"\xa3",
         b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.",
         b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
@@ -170,6 +152,25 @@ _2y_test_vectors = [
         b"\xff\xff\xa3",
         b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
         b"$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
+    ),
+]
+
+_long_pw_vectors = [
+    (
+        b"0123456789abcdefghijklmnopqrstuvwxyz"
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        b"chars after 72 are ignored",
+        b"$2a$05$abcdefghijklmnopqrstuu",
+    ),
+    (
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+        b"chars after 72 are ignored as usual",
+        b"$2a$05$/OK.fbVrR/bpIqNJ5ianF.",
     ),
 ]
 
@@ -250,6 +251,12 @@ def test_hashpw_2y_prefix(password, hashed, expected):
 @pytest.mark.parametrize(("password", "hashed", "expected"), _2y_test_vectors)
 def test_checkpw_2y_prefix(password, hashed, expected):
     assert bcrypt.checkpw(password, hashed) is True
+
+
+@pytest.mark.parametrize(("password", "salt"), _long_pw_vectors)
+def test_hashpw_raises_on_passwords_longer_than_72_chars(password, salt):
+    with pytest.raises(ValueError):
+        bcrypt.hashpw(password, salt)
 
 
 def test_hashpw_invalid():

--- a/tests/test_bcrypt.py
+++ b/tests/test_bcrypt.py
@@ -259,6 +259,25 @@ def test_hashpw_raises_on_passwords_longer_than_72_chars(password, salt):
         bcrypt.hashpw(password, salt)
 
 
+@pytest.mark.parametrize(
+    ("pw_length", "should_raise"),
+    [
+        (71, False),
+        (72, False),
+        (73, True),
+    ],
+)
+def test_hashpw_raises_correctly_for_long_passwords(pw_length, should_raise):
+    password = b"\xaa" * pw_length
+    salt = b"$2b$04$xnFVhJsTzsFBTeP3PpgbMe"
+
+    if should_raise:
+        with pytest.raises(ValueError):
+            bcrypt.hashpw(password, salt)
+    else:
+        bcrypt.hashpw(password, salt)
+
+
 def test_hashpw_invalid():
     with pytest.raises(ValueError):
         bcrypt.hashpw(b"password", b"$2z$04$cVWp4XaNU8a4v1uMRum2SO")


### PR DESCRIPTION
See discussion in #969

Moved some existing test cases (that ensured bytes after the 72th were truncated) to a separate fixture and wrote new tests to assert an exception is raised.

`test_2a_wraparound_bug` is failing with this change, I have to better understand what exactly this is doing and if/how it should be updated.