### PR TITLE
replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: quansight-labs/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
       - uses: actions/cache@v4.2.3
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: quansight-labs/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup python
         id: setup-python
-        uses: quansight-labs/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
       - uses: actions/cache@v4.2.3

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           name: bcrypt-sdist
       - name: Setup python
-        uses: quansight-labs/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.