### PR TITLE
5.0.0 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,15 @@ While bcrypt remains an acceptable choice for password storage, depending on you
 Changelog
 =========
 
-Unreleased
-----------
+5.0.0
+-----
 
 * Bumped MSRV to 1.74.
 * Added support for Python 3.14 and free-threaded Python 3.14.
+* Added support for Windows on ARM.
+* Passing ``hashpw`` a password longer than 72 bytes now raises a
+  ``ValueError``. Previously the password was silently truncated, following the
+  behavior of the original OpenBSD ``bcrypt`` implementation.
 
 4.3.0
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "bcrypt"
 # When updating this, also update lib.rs
-version = "4.3.0"
+version = "5.0.0"
 authors = [
     {name = "The Python Cryptographic Authority developers", email = "cryptography-dev@python.org"}
 ]

--- a/src/_bcrypt/src/lib.rs
+++ b/src/_bcrypt/src/lib.rs
@@ -210,7 +210,7 @@ mod _bcrypt {
         // When updating this, also update pyproject.toml
         // This isn't named __version__ because passlib treats the existence of
         // that attribute as proof that we're a different module
-        m.add("__version_ex__", "4.3.0")?;
+        m.add("__version_ex__", "5.0.0")?;
 
         let author = "The Python Cryptographic Authority developers";
         m.add("__author__", author)?;


### PR DESCRIPTION
Fixes #1076.

Following https://github.com/pyca/bcrypt/pull/985, I *think* this is all that's necessary.