### PR TITLE
ci: add riscv64 manylinux wheel builds

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -153,7 +153,10 @@ jobs:
           key: bcrypt-riscv64-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             bcrypt-riscv64-cargo-
-      - run: /opt/python-3.12/bin/python3.12 -m venv .venv
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python3 -m venv .venv
       - name: Install python dependencies
         run: .venv/bin/pip install -U pip wheel setuptools-rust auditwheel
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -127,6 +127,69 @@ jobs:
           name: "bcrypt-${{ github.event.inputs.version }}-${{ matrix.MANYLINUX.NAME }}-${{ matrix.PYTHON.VERSION  }}${{ matrix.PYTHON.ABI_VERSION }}"
           path: bcrypt-wheelhouse/
 
+  manylinux-riscv64:
+    needs: [sdist]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        PYTHON:
+          - { VERSION: "cp39-cp39", ABI_VERSION: 'cp39' }
+          - { VERSION: "cp313-cp313t" }
+          - { VERSION: "cp314-cp314t" }
+        MANYLINUX:
+          - { NAME: "manylinux_2_39_riscv64", CONTAINER: "manylinux_2_39_riscv64" }
+    name: "${{ matrix.PYTHON.VERSION }} for ${{ matrix.MANYLINUX.NAME }}"
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: riscv64
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bcrypt-sdist
+          path: sdist
+      - name: Build and test the wheel
+        env:
+          PYTHON_VERSION: ${{ matrix.PYTHON.VERSION }}
+          ABI_VERSION: ${{ matrix.PYTHON.ABI_VERSION }}
+          CONTAINER: ${{ matrix.MANYLINUX.CONTAINER }}
+        run: |
+          docker run --rm \
+            --platform linux/riscv64 \
+            -v "$(pwd)/sdist:/sdist" \
+            -v "$(pwd)/wheelhouse:/wheelhouse" \
+            -e PYTHON_VERSION \
+            -e ABI_VERSION \
+            "quay.io/pypa/${CONTAINER}" \
+            bash -c '
+              set -eux
+              # Install Rust
+              curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+              export PATH="/root/.cargo/bin:$PATH"
+
+              /opt/python/${PYTHON_VERSION}/bin/python -m venv /venv
+              /venv/bin/pip install -U pip wheel setuptools-rust
+
+              mkdir /tmp/tmpwheelhouse
+              PY_LIMITED_API=""
+              if [ -n "${ABI_VERSION:-}" ]; then
+                  PY_LIMITED_API="--config-settings=--build-option=--py-limited-api=${ABI_VERSION} --no-build-isolation"
+              fi
+              /venv/bin/python -m pip wheel -v ${PY_LIMITED_API} /sdist/bcrypt*.tar.gz -w /tmp/dist/ && \
+                mv /tmp/dist/bcrypt*.whl /tmp/tmpwheelhouse/
+
+              auditwheel repair /tmp/tmpwheelhouse/bcrypt*.whl -w /wheelhouse/
+              /venv/bin/pip install bcrypt --no-index -f /wheelhouse/
+              /venv/bin/python -c "import bcrypt; password = b'"'"'super secret password'"'"'; hashed = bcrypt.hashpw(password, bcrypt.gensalt()); bcrypt.checkpw(password, hashed)"
+            '
+      - run: mkdir bcrypt-wheelhouse
+      - run: mv wheelhouse/bcrypt*.whl bcrypt-wheelhouse/
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: "bcrypt-${{ github.event.inputs.version }}-${{ matrix.MANYLINUX.NAME }}-${{ matrix.PYTHON.VERSION  }}${{ matrix.PYTHON.ABI_VERSION }}"
+          path: bcrypt-wheelhouse/
+
   macos:
     needs: [sdist]
     runs-on: macos-15

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -129,65 +129,49 @@ jobs:
 
   manylinux-riscv64:
     needs: [sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-riscv
     strategy:
       fail-fast: false
       matrix:
         PYTHON:
-          - { VERSION: "cp39-cp39", ABI_VERSION: 'cp39' }
-          - { VERSION: "cp313-cp313t" }
-          - { VERSION: "cp314-cp314t" }
-        MANYLINUX:
-          - { NAME: "manylinux_2_39_riscv64", CONTAINER: "manylinux_2_39_riscv64" }
-    name: "${{ matrix.PYTHON.VERSION }} for ${{ matrix.MANYLINUX.NAME }}"
+          - { VERSION: "cp39-cp39", ABI_VERSION: "" }
+          - { VERSION: "cp312-cp312", ABI_VERSION: "" }
+    name: "${{ matrix.PYTHON.VERSION }} for manylinux_riscv64"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf libffi-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Cache Rust artifacts
+        uses: actions/cache@v4
         with:
-          platforms: riscv64
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: bcrypt-riscv64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            bcrypt-riscv64-cargo-
+      - run: /opt/python-3.12/bin/python3.12 -m venv .venv
+      - name: Install python dependencies
+        run: .venv/bin/pip install -U pip wheel setuptools-rust auditwheel
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: bcrypt-sdist
-          path: sdist
-      - name: Build and test the wheel
-        env:
-          PYTHON_VERSION: ${{ matrix.PYTHON.VERSION }}
-          ABI_VERSION: ${{ matrix.PYTHON.ABI_VERSION }}
-          CONTAINER: ${{ matrix.MANYLINUX.CONTAINER }}
+      - run: mkdir tmpwheelhouse
+      - name: Build the wheel
         run: |
-          docker run --rm \
-            --platform linux/riscv64 \
-            -v "$(pwd)/sdist:/sdist" \
-            -v "$(pwd)/wheelhouse:/wheelhouse" \
-            -e PYTHON_VERSION \
-            -e ABI_VERSION \
-            "quay.io/pypa/${CONTAINER}" \
-            bash -c '
-              set -eux
-              # Install Rust
-              curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
-              export PATH="/root/.cargo/bin:$PATH"
-
-              /opt/python/${PYTHON_VERSION}/bin/python -m venv /venv
-              /venv/bin/pip install -U pip wheel setuptools-rust
-
-              mkdir /tmp/tmpwheelhouse
-              PY_LIMITED_API=""
-              if [ -n "${ABI_VERSION:-}" ]; then
-                  PY_LIMITED_API="--config-settings=--build-option=--py-limited-api=${ABI_VERSION} --no-build-isolation"
-              fi
-              /venv/bin/python -m pip wheel -v ${PY_LIMITED_API} /sdist/bcrypt*.tar.gz -w /tmp/dist/ && \
-                mv /tmp/dist/bcrypt*.whl /tmp/tmpwheelhouse/
-
-              auditwheel repair /tmp/tmpwheelhouse/bcrypt*.whl -w /wheelhouse/
-              /venv/bin/pip install bcrypt --no-index -f /wheelhouse/
-              /venv/bin/python -c "import bcrypt; password = b'"'"'super secret password'"'"'; hashed = bcrypt.hashpw(password, bcrypt.gensalt()); bcrypt.checkpw(password, hashed)"
-            '
+          .venv/bin/python -m pip wheel -v bcrypt*.tar.gz -w dist/ && mv dist/bcrypt*.whl tmpwheelhouse
+      - run: .venv/bin/auditwheel repair tmpwheelhouse/bcrypt*.whl -w wheelhouse/
+      - run: .venv/bin/pip install bcrypt --no-index -f wheelhouse/
+      - run: |
+          .venv/bin/python -c "import bcrypt; password = b'super secret password';hashed = bcrypt.hashpw(password, bcrypt.gensalt());bcrypt.checkpw(password, hashed)"
       - run: mkdir bcrypt-wheelhouse
       - run: mv wheelhouse/bcrypt*.whl bcrypt-wheelhouse/
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
-          name: "bcrypt-${{ github.event.inputs.version }}-${{ matrix.MANYLINUX.NAME }}-${{ matrix.PYTHON.VERSION  }}${{ matrix.PYTHON.ABI_VERSION }}"
+          name: "bcrypt-${{ github.event.inputs.version }}-manylinux_riscv64-${{ matrix.PYTHON.VERSION }}"
           path: bcrypt-wheelhouse/
 
   macos:


### PR DESCRIPTION
Add native riscv64 wheel builds using [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners) (`ubuntu-24.04-riscv`) — no QEMU emulation.

## Changes

- New `manylinux-riscv64` job in `wheel-builder.yml`
- Uses native RISE riscv64 runners (as discussed — no QEMU)
- Installs Rust via rustup, Python from /opt/python-3.12
- Cargo registry cached across runs
- Same smoke test as existing jobs

## Evidence

- Build time: ~5.5 minutes on native hardware
- Validated on RISE fork: https://github.com/riseproject-dev/bcrypt/pull/1
- Native build on BananaPi F3 (SpacemiT K1, rv64gc): SUCCESS
- RISE runners provided by Ludovic Henry / RISE project (free for open source)

## Context

Updated per @reaperhulk's feedback — switched from QEMU to native runners.

Related: riscv64 Docker images for pyca infra: https://github.com/pyca/infra/issues/748