### PR TITLE
Upgrade CI linux job from ubuntu-22.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
           CARGO_TARGET_DIR: ${{ format('{0}/src/_bcrypt/target/', github.workspace) }}
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Switches the `linux` job in `.github/workflows/ci.yml` from the `ubuntu-22.04` runner to `ubuntu-latest`. This was the only remaining `ubuntu-22.04` reference in the workflows — the other jobs already use `ubuntu-latest` or ARM runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL6GoojdHP7SfDSbPcG1LE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VL6GoojdHP7SfDSbPcG1LE)_