### PR TITLE
fix: AttributeError: module 'bcrypt' has no attribute '__about__' with

### DIFF
--- a/src/bcrypt/__init__.py
+++ b/src/bcrypt/__init__.py
@@ -26,8 +26,10 @@ from ._bcrypt import (
 from ._bcrypt import (
     __version_ex__ as __version__,
 )
+from . import __about__
 
 __all__ = [
+    "__about__",
     "__author__",
     "__copyright__",
     "__email__",


### PR DESCRIPTION
Fixes #684

### Root cause

See the linked issue #684 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `src/bcrypt/__init__.py`

### Verification

- `pytest -q --tb=long --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
